### PR TITLE
feat: add Hybrid KEMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ Web Cryptography API, namely:
 - SHA-3, cSHAKE, TurboSHAKE, and KangarooTwelve
 - KMAC
 - Argon2
+- Hybrid KEMs
 
-To accommodate the usage of ML-KEM, and possibly future other KEMs,
+To accommodate the usage of ML-KEM, Hybrid KEMs, and possibly future other KEMs,
 it proposes to add functions for key encapsulation and decapsulation;
 `SubtleCrypto.encapsulateKey`, `SubtleCrypto.encapsulateBits`,
 `SubtleCrypto.decapsulateKey` and `SubtleCrypto.decapsulateBits`.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ post-quantum secure and modern cryptographic algorithms in the
 Web Cryptography API, namely:
 
 - ML-KEM
+- Hybrid KEMs
 - ML-DSA
 - SLH-DSA
 - AES-OCB
@@ -12,7 +13,6 @@ Web Cryptography API, namely:
 - SHA-3, cSHAKE, TurboSHAKE, and KangarooTwelve
 - KMAC
 - Argon2
-- Hybrid KEMs
 
 To accommodate the usage of ML-KEM, Hybrid KEMs, and possibly future other KEMs,
 it proposes to add functions for key encapsulation and decapsulation;

--- a/index.html
+++ b/index.html
@@ -120,6 +120,18 @@
         "href": "https://datatracker.ietf.org/doc/draft-ietf-hpke-hpke/",
         "publisher": "IETF"
       },
+      "draft-irtf-cfrg-hybrid-kems-09": {
+        "title": "Hybrid PQ/T Key Encapsulation Mechanisms",
+        "href": "https://www.ietf.org/archive/id/draft-irtf-cfrg-hybrid-kems-09.html",
+        "publisher": "IETF",
+        "date": "March 2026"
+      },
+      "draft-irtf-cfrg-concrete-hybrid-kems-03": {
+        "title": "Concrete Hybrid PQ/T Key Encapsulation Mechanisms",
+        "href": "https://www.ietf.org/archive/id/draft-irtf-cfrg-concrete-hybrid-kems-03.html",
+        "publisher": "IETF",
+        "date": "March 2026"
+      },
     },
   };
   </script>
@@ -130,8 +142,9 @@
     <p>
       This specification defines a number of post-quantum secure and
       modern cryptographic algorithms for the [[webcrypto | Web Cryptography API]],
-      namely ML-KEM, ML-DSA, SLH-DSA, AES-OCB, ChaCha20-Poly1305,
-      SHA-3, cSHAKE, TurboSHAKE, KangarooTwelve, KMAC, and Argon2.
+      namely ML-KEM, Hybrid KEMs, ML-DSA, SLH-DSA, AES-OCB,
+      ChaCha20-Poly1305, SHA-3, cSHAKE, TurboSHAKE, KangarooTwelve,
+      KMAC, and Argon2.
     </p>
   </section>
   <section id="sotd">
@@ -150,6 +163,7 @@
     </p>
     <ul>
       <li><a href="#ml-kem">ML-KEM</a> [[FIPS-203]]</li>
+      <li><a href="#hybrid-kems">Hybrid KEMs</a> [[draft-irtf-cfrg-concrete-hybrid-kems-03]]</li>
       <li><a href="#ml-dsa">ML-DSA</a> [[FIPS-204]]</li>
       <li><a href="#slh-dsa">SLH-DSA</a> [[FIPS-205]]</li>
       <li><a href="#aes-ocb">AES-OCB</a> [[RFC7253]]</li>
@@ -160,7 +174,7 @@
       <li><a href="#argon2">Argon2d, Argon2i, and Argon2id</a> [[RFC9106]]</li>
     </ul>
     <p>
-      To accommodate the usage of ML-KEM, and possibly future other KEMs,
+      To accommodate the usage of ML-KEM, Hybrid KEMs, and possibly future other KEMs,
       this proposal introduces functions for key encapsulation and decapsulation;
       <a href="#dfn-SubtleCrypto-method-encapsulateKey">`SubtleCrypto.encapsulateKey`</a>,
       <a href="#dfn-SubtleCrypto-method-encapsulateBits">`SubtleCrypto.encapsulateBits`</a>,
@@ -7367,6 +7381,740 @@ dictionary Argon2Params : Algorithm {
     </section>
   </section>
 
+  <section id="hybrid-kems">
+    <h3>Hybrid KEMs</h3>
+    <section id="hybrid-kems-description" class="informative">
+      <h4>Description</h4>
+      <p>
+        This describes using hybrid post-quantum/traditional key
+        encapsulation mechanisms for key encapsulation and decapsulation,
+        as specified by [[draft-irtf-cfrg-concrete-hybrid-kems-03]].
+      </p>
+    </section>
+    <section id="hybrid-kems-registration">
+      <h4>Registration</h4>
+      <p>
+        The <a data-cite="webcrypto#recognized-algorithm-name">recognized algorithm names</a> for
+        this algorithm are "`MLKEM768-P256`", "`MLKEM768-X25519`" and
+        "`MLKEM1024-P384`".
+      </p>
+      <table>
+        <thead>
+          <tr>
+            <th><a data-cite="webcrypto#supported-operations">Operation</a></th>
+            <th><a data-cite="webcrypto#algorithm-specific-params">Parameters</a></th>
+            <th><a data-cite="webcrypto#algorithm-result">Result</a></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>encapsulate</td>
+            <td>None</td>
+            <td>{{EncapsulatedBits}}</td>
+          </tr>
+          <tr>
+            <td>decapsulate</td>
+            <td>None</td>
+            <td>[= byte sequence =]</td>
+          </tr>
+          <tr>
+            <td>generateKey</td>
+            <td>None</td>
+            <td>{{CryptoKeyPair}}</td>
+          </tr>
+          <tr>
+            <td>importKey</td>
+            <td>None</td>
+            <td>{{CryptoKey}}</td>
+          </tr>
+          <tr>
+            <td>exportKey</td>
+            <td>None</td>
+            <td>object</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+    <section id="hybrid-kems-operations">
+      <h4>Operations</h4>
+      <section id="hybrid-kems-operations-encapsulate">
+        <h5>Encapsulate</h5>
+        <ol>
+          <li>
+            <p>
+              If the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot of
+              |key| is not {{KeyType/"public"}}, then [= exception/throw =] an {{InvalidAccessError}}.
+            </p>
+          </li>
+          <li>
+            <p>
+              Let |sharedKey| and |ciphertext| be the outputs that result
+              from performing the Encaps function for the hybrid
+              KEM instance indicated by the {{Algorithm/name}} member of
+              |algorithm| in Section 4 of
+              [[draft-irtf-cfrg-concrete-hybrid-kems-03]], using the key
+              represented by the <a data-cite="webcrypto#dfn-CryptoKey-slot-handle">`[[handle]]`</a>
+              internal slot of |key| as the |ek| input parameter.
+            </p>
+          </li>
+          <li>
+            <p>
+              If the Encaps function returned an error, return an {{OperationError}}.
+            </p>
+          </li>
+          <li>
+            <p>
+              Let |result| be a new {{EncapsulatedBits}}
+              dictionary.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the {{EncapsulatedBits/sharedKey}} attribute
+              of |result| to the result of [= ArrayBuffer/create | creating =]
+              an {{ArrayBuffer}} containing |sharedKey|.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the {{EncapsulatedBits/ciphertext}} attribute
+              of |result| to the result of [= ArrayBuffer/create | creating =]
+              an {{ArrayBuffer}} containing |ciphertext|.
+            </p>
+          </li>
+          <li>
+            <p>
+              Return |result|.
+            </p>
+          </li>
+        </ol>
+      </section>
+      <section id="hybrid-kems-operations-decapsulate">
+        <h5>Decapsulate</h5>
+        <ol>
+          <li>
+            <p>
+              If the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot of
+              |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
+            </p>
+          </li>
+          <li>
+            <p>
+              Let |sharedKey| be the output that results from performing
+              the Decaps function for the hybrid KEM instance
+              indicated by the {{Algorithm/name}} member of |algorithm| in
+              Section 4 of [[draft-irtf-cfrg-concrete-hybrid-kems-03]],
+              using the key represented by the <a data-cite="webcrypto#dfn-CryptoKey-slot-handle">`[[handle]]`</a>
+              internal slot of |key| as the |dk| input parameter, and
+              |ciphertext| as the |ct| input parameter.
+            </p>
+          </li>
+          <li>
+            <p>
+              If the Decaps function returned an error, return an {{OperationError}}.
+            </p>
+          </li>
+          <li>
+            <p>
+              Return |sharedKey|.
+            </p>
+          </li>
+        </ol>
+      </section>
+      <section id="hybrid-kems-operations-generate-key">
+        <h5>Generate Key</h5>
+        <ol>
+          <li>
+            <p>
+              If |usages| contains an entry which is not
+              one of "`encapsulateKey`", "`encapsulateBits`",
+              "`decapsulateKey`" or "`decapsulateBits`",
+              then [= exception/throw =] a
+              {{SyntaxError}}.
+            </p>
+          </li>
+          <li>
+            <p>
+              Generate a hybrid KEM key pair by performing the
+              GenerateKeyPair function described in Section 5.2 of
+              [[draft-irtf-cfrg-hybrid-kems-09]] with the hybrid
+              KEM instance indicated by the {{Algorithm/name}} member of
+              |normalizedAlgorithm|.
+            </p>
+          </li>
+          <li>
+            <p>
+              If the key generation step fails,
+              then [= exception/throw =] an
+              {{OperationError}}.
+            </p>
+          </li>
+          <li>
+            <p>
+              Let |algorithm| be a new {{KeyAlgorithm}} object.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the {{KeyAlgorithm/name}} attribute of
+              |algorithm| to the {{Algorithm/name}} attribute of
+              |normalizedAlgorithm|.
+            </p>
+          </li>
+          <li>
+            <p>
+              Let |publicKey| be a new {{CryptoKey}}
+              representing the encapsulation key of the generated key pair.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot of
+              |publicKey| to {{KeyType/"public"}}.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-algorithm">`[[algorithm]]`</a> internal
+              slot of |publicKey| to |algorithm|.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-extractable">`[[extractable]]`</a> internal
+              slot of |publicKey| to true.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-usages">`[[usages]]`</a> internal slot of
+              |publicKey| to be the
+              <a data-cite="webcrypto#concept-usage-intersection">usage intersection</a> of
+              |usages| and `[ "encapsulateKey", "encapsulateBits" ]`.
+            </p>
+          </li>
+          <li>
+            <p>
+              Let |privateKey| be a new {{CryptoKey}}
+              representing the decapsulation key of the generated key pair.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot of
+              |privateKey| to {{KeyType/"private"}}.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-algorithm">`[[algorithm]]`</a> internal
+              slot of |privateKey| to |algorithm|.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-extractable">`[[extractable]]`</a> internal
+              slot of |privateKey| to |extractable|.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-usages">`[[usages]]`</a> internal slot of
+              |privateKey| to be the
+              <a data-cite="webcrypto#concept-usage-intersection">usage intersection</a> of
+              |usages| and `[ "decapsulateKey", "decapsulateBits" ]`.
+            </p>
+          </li>
+          <li>
+            <p>
+              Let |result| be a new {{CryptoKeyPair}}
+              dictionary.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the {{CryptoKeyPair/publicKey}} attribute
+              of |result| to be |publicKey|.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the {{CryptoKeyPair/privateKey}} attribute
+              of |result| to be |privateKey|.
+            </p>
+          </li>
+          <li>
+            <p>
+              Return |result|.
+            </p>
+          </li>
+        </ol>
+      </section>
+      <section id="hybrid-kems-operations-import-key">
+        <h5>Import Key</h5>
+        <div class=note>
+          <p>
+            TODO: {{KeyFormat/"spki"}} and {{KeyFormat/"pkcs8"}}.
+          </p>
+        </div>
+        <ol>
+          <li>
+            <p>Let |keyData| be the key data to be imported.</p>
+          </li>
+          <li>
+            <dl class="switch">
+              <dt>If |format| is {{KeyFormat/"raw-public"}}:</dt>
+              <dd>
+                <ol>
+                  <li>
+                    <p>
+                      If |usages| contains an entry which is not
+                      "`encapsulateKey`" or "`encapsulateBits`"
+                      then [= exception/throw =] a
+                      {{SyntaxError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |data| be |keyData|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the length in bytes of |data| is not the raw public key
+                      length, `Nek`, for the hybrid KEM instance
+                      indicated by the {{Algorithm/name}} member of
+                      |normalizedAlgorithm| in Section 4 of
+                      [[draft-irtf-cfrg-concrete-hybrid-kems-03]], then
+                      [= exception/throw =] a {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |key| be a new {{CryptoKey}}
+                      that represents the hybrid KEM public key data in |data|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot
+                      of |key| to {{KeyType/"public"}}
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |algorithm| be a new {{KeyAlgorithm}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the {{KeyAlgorithm/name}} attribute of
+                      |algorithm| to the {{Algorithm/name}} attribute of
+                      |normalizedAlgorithm|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-algorithm">`[[algorithm]]`</a>
+                      internal slot of |key| to |algorithm|.
+                    </p>
+                  </li>
+                </ol>
+              </dd>
+              <dt>If |format| is {{KeyFormat/"raw-seed"}}:</dt>
+              <dd>
+                <ol>
+                  <li>
+                    <p>
+                      If |usages| contains an entry which is not
+                      "`decapsulateKey`" or "`decapsulateBits`"
+                      then [= exception/throw =] a
+                      {{SyntaxError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |data| be |keyData|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the length in bits of |data| is not 256
+                      then [= exception/throw =] a
+                      {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |keyPair| be the result of performing the
+                      DeriveKeyPair function described in Section 5.5 of
+                      [[draft-irtf-cfrg-hybrid-kems-09]] with the
+                      hybrid KEM instance indicated by the {{Algorithm/name}}
+                      member of |normalizedAlgorithm|, using |data| as the
+                      |seed| input parameter.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the DeriveKeyPair function returned an error,
+                      then [= exception/throw =] an {{OperationError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |key| be a new {{CryptoKey}}
+                      that represents the hybrid KEM private key identified by
+                      the decapsulation key of |keyPair|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot
+                      of |key| to {{KeyType/"private"}}
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |algorithm| be a new {{KeyAlgorithm}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the {{KeyAlgorithm/name}} attribute of
+                      |algorithm| to the {{Algorithm/name}} attribute of
+                      |normalizedAlgorithm|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-algorithm">`[[algorithm]]`</a>
+                      internal slot of |key| to |algorithm|.
+                    </p>
+                  </li>
+                </ol>
+              </dd>
+              <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
+              <dd>
+                <ol>
+                  <li>
+                    <dl class="switch">
+                      <dt>If |keyData| is a {{JsonWebKey}} dictionary:</dt>
+                      <dd><p>Let |jwk| equal |keyData|.</p></dd>
+                      <dt>Otherwise:</dt>
+                      <dd><p>[= exception/Throw =] a {{DataError}}.</p></dd>
+                    </dl>
+                  </li>
+                  <li>
+                    <p>
+                      If the {{JsonWebKey/priv}} field of |jwk| is present
+                      and if |usages| contains an entry which is not
+                      "`decapsulateKey`" or "`decapsulateBits`"
+                      then [= exception/throw =] a
+                      {{SyntaxError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the {{JsonWebKey/priv}} field of |jwk| is not present
+                      and if |usages| contains an entry which is not
+                      "`encapsulateKey`" or "`encapsulateBits`"
+                      then [= exception/throw =] a
+                      {{SyntaxError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the {{JsonWebKey/kty}} field of |jwk| is not
+                      "`AKP`",
+                      then [= exception/throw =] a
+                      {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the {{JsonWebKey/alg}} field of |jwk| is not
+                      equal to the {{Algorithm/name}} member of
+                      |normalizedAlgorithm|, then [= exception/throw =] a
+                      {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If |usages| is non-empty and the {{JsonWebKey/use}} field of |jwk| is present
+                      and is not equal to "`enc`", then [= exception/throw =] a
+                      {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the {{JsonWebKey/key_ops}} field of |jwk| is present, and
+                      is invalid according to the requirements of JSON Web
+                      Key [[JWK]], or it does not contain all of the specified |usages|
+                      values,
+                      then [= exception/throw =] a
+                      {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the {{JsonWebKey/ext}} field of |jwk| is present and
+                      has the value false and |extractable| is true,
+                      then [= exception/throw =] a
+                      {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <dl class="switch">
+                      <dt>If the {{JsonWebKey/priv}} field of |jwk| is present:</dt>
+                      <dd>
+                        <ol>
+                          <li>
+                            <p>
+                              If the {{JsonWebKey/priv}} attribute of |jwk|
+                              does not contain a valid base64url encoded
+                              32-byte seed representing a hybrid KEM private key,
+                              then [= exception/throw =] a {{DataError}}.
+                            </p>
+                          </li>
+                          <li>
+                            <p>
+                              Let |key| be a new {{CryptoKey}} object that represents the
+                              hybrid KEM private key identified by interpreting the
+                              {{JsonWebKey/priv}} attribute of |jwk|
+                              as a base64url encoded seed.
+                            </p>
+                          </li>
+                          <li>
+                            <p>
+                              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a>
+                              internal slot of |key| to {{KeyType/"private"}}.
+                            </p>
+                          </li>
+                          <li>
+                            <p>
+                              If the {{JsonWebKey/pub}} attribute of |jwk|
+                              does not contain the base64url encoded public key
+                              representing the hybrid KEM public key
+                              corresponding to |key|,
+                              then [= exception/throw =] a {{DataError}}.
+                            </p>
+                          </li>
+                        </ol>
+                      </dd>
+                      <dt>Otherwise:</dt>
+                      <dd>
+                        <ol>
+                          <li>
+                            <p>
+                              If the {{JsonWebKey/pub}} attribute of |jwk|
+                              does not contain a valid base64url encoded raw
+                              public key whose length is `Nek` for the
+                              hybrid KEM instance indicated by the
+                              {{Algorithm/name}} member of
+                              |normalizedAlgorithm| in Section 4 of
+                              [[draft-irtf-cfrg-concrete-hybrid-kems-03]],
+                              then [= exception/throw =] a {{DataError}}.
+                            </p>
+                          </li>
+                          <li>
+                            <p>
+                              Let |key| be a new {{CryptoKey}} object that represents the
+                              hybrid KEM public key identified by interpreting the
+                              {{JsonWebKey/pub}} attribute of |jwk|
+                              as a base64url encoded public key.
+                            </p>
+                          </li>
+                          <li>
+                            <p>
+                              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a>
+                              internal slot of |key| to {{KeyType/"public"}}.
+                            </p>
+                          </li>
+                        </ol>
+                      </dd>
+                    </dl>
+                  </li>
+                  <li>
+                    <p>
+                      Let |algorithm| be a new instance of a {{KeyAlgorithm}} object.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the {{KeyAlgorithm/name}} attribute of
+                      |algorithm| to the {{Algorithm/name}} member of |normalizedAlgorithm|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-algorithm">`[[algorithm]]`</a>
+                      internal slot of |key| to |algorithm|.
+                    </p>
+                  </li>
+                </ol>
+              </dd>
+              <dt>Otherwise:</dt>
+              <dd>
+                [= exception/throw =] a
+                {{NotSupportedError}}.
+              </dd>
+            </dl>
+          </li>
+          <li>
+            <p>
+              Return |key|.
+            </p>
+          </li>
+        </ol>
+      </section>
+      <section id="hybrid-kems-operations-export-key">
+        <h5>Export Key</h5>
+        <ol>
+          <li>
+            <p>
+              Let |key| be the {{CryptoKey}} to be
+              exported.
+            </p>
+          </li>
+          <li>
+            <p>
+              If the underlying cryptographic key material represented by the <a data-cite="webcrypto#dfn-CryptoKey-slot-handle">`[[handle]]`</a> internal slot of |key|
+              cannot be accessed, then [= exception/throw =] an {{OperationError}}.
+            </p>
+          </li>
+          <li>
+            <dl class="switch">
+              <dt>If |format| is {{KeyFormat/"raw-public"}}:</dt>
+              <dd>
+                <ol>
+                  <li>
+                    <p>
+                      If the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot
+                      of |key| is not {{KeyType/"public"}}, then [= exception/throw =] an {{InvalidAccessError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |data| be a [= byte sequence =] containing
+                      the raw octets of the key represented by the <a data-cite="webcrypto#dfn-CryptoKey-slot-handle">`[[handle]]`</a> internal slot of
+                      |key|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |result| be |data|.
+                    </p>
+                  </li>
+                </ol>
+              </dd>
+              <dt>If |format| is {{KeyFormat/"raw-seed"}}:</dt>
+              <dd>
+                <ol>
+                  <li>
+                    <p>
+                      If the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot
+                      of |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |data| be a [= byte sequence =] containing the 32-byte seed represented by
+                      the <a data-cite="webcrypto#dfn-CryptoKey-slot-handle">`[[handle]]`</a>
+                      internal slot of |key|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |result| be |data|.
+                    </p>
+                  </li>
+                </ol>
+              </dd>
+              <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
+              <dd>
+                <ol>
+                  <li>
+                    <p>
+                      Let |jwk| be a new {{JsonWebKey}}
+                      dictionary.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |keyAlgorithm| be the <a data-cite="webcrypto#dfn-CryptoKey-slot-algorithm">`[[algorithm]]`</a> internal slot of |key|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the `kty` attribute of |jwk| to
+                      "`AKP`".
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the `alg` attribute of |jwk| to the
+                      {{Algorithm/name}} member of |keyAlgorithm|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the {{JsonWebKey/pub}} attribute of |jwk|
+                      to the base64url encoded public key corresponding
+                      to the <a data-cite="webcrypto#dfn-CryptoKey-slot-handle">`[[handle]]`</a>
+                      internal slot of |key|.
+                    </p>
+                  </li>
+                  <li>
+                    <dl class="switch">
+                      <dt>
+                        If the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot
+                        of |key| is {{KeyType/"private"}}:
+                      </dt>
+                      <dd>
+                        Set the {{JsonWebKey/priv}} attribute of |jwk|
+                        to the base64url encoded 32-byte seed represented by
+                        the <a data-cite="webcrypto#dfn-CryptoKey-slot-handle">`[[handle]]`</a>
+                        internal slot of |key|.
+                      </dd>
+                    </dl>
+                  </li>
+                  <li>
+                    <p>
+                      Set the `key_ops` attribute of |jwk| to the {{CryptoKey/usages}} attribute of |key|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the `ext` attribute of |jwk| to the <a data-cite="webcrypto#dfn-CryptoKey-slot-extractable">`[[extractable]]`</a> internal slot
+                      of |key|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |result| be |jwk|.
+                    </p>
+                  </li>
+                </ol>
+              </dd>
+              <dt>Otherwise:</dt>
+              <dd>
+                <p>
+                  [= exception/throw =] a
+                  {{NotSupportedError}}.
+                </p>
+              </dd>
+            </dl>
+          </li>
+          <li>
+            <p>
+              Return |result|.
+            </p>
+          </li>
+        </ol>
+      </section>
+    </section>
+  </section>
+
   <section id="iana-section">
     <h2>IANA Considerations</h2>
     <section id="iana-section-jws-jwa">
@@ -7519,6 +8267,30 @@ dictionary Argon2Params : Algorithm {
         <li>Change Controller: W3C Web Application Security Working Group</li>
         <li>Specification Document(s): [[ This Document ]]</li>
       </ul>
+      <ul>
+        <li>Algorithm Name: "MLKEM768-P256"</li>
+        <li>Algorithm Description: Hybrid KEM using ML-KEM-768 and P-256</li>
+        <li>Algorithm Usage Location(s): "JWK"</li>
+        <li>JOSE Implementation Requirements: Optional</li>
+        <li>Change Controller: W3C Web Application Security Working Group</li>
+        <li>Specification Document(s): [[ This Document ]]</li>
+      </ul>
+      <ul>
+        <li>Algorithm Name: "MLKEM768-X25519"</li>
+        <li>Algorithm Description: Hybrid KEM using ML-KEM-768 and X25519</li>
+        <li>Algorithm Usage Location(s): "JWK"</li>
+        <li>JOSE Implementation Requirements: Optional</li>
+        <li>Change Controller: W3C Web Application Security Working Group</li>
+        <li>Specification Document(s): [[ This Document ]]</li>
+      </ul>
+      <ul>
+        <li>Algorithm Name: "MLKEM1024-P384"</li>
+        <li>Algorithm Description: Hybrid KEM using ML-KEM-1024 and P-384</li>
+        <li>Algorithm Usage Location(s): "JWK"</li>
+        <li>JOSE Implementation Requirements: Optional</li>
+        <li>Change Controller: W3C Web Application Security Working Group</li>
+        <li>Specification Document(s): [[ This Document ]]</li>
+      </ul>
     </section>
     <section id="iana-section-key-operations">
       <h3>JSON Web Key Operations</h3>
@@ -7590,6 +8362,11 @@ dictionary Argon2Params : Algorithm {
         post-quantum/traditional (PQ/T) key establishment as used in
         protocols like [[draft-ietf-hpke-hpke]] and its PQ and PQ/T
         algorithms [[draft-ietf-hpke-pq]].
+      </li>
+      <li>
+        <a href="#hybrid-kems">Hybrid KEMs</a> provide
+        post-quantum/traditional KEM instances that combine ML-KEM with
+        P-256, X25519, or P-384 [[draft-irtf-cfrg-concrete-hybrid-kems-03]].
       </li>
       <li>
         <a href="#ml-dsa">ML-DSA</a> is the primary post-quantum digital
@@ -7774,6 +8551,45 @@ alg: "C20P" }
           <td>
 <pre class=js>
 { name: "ChaCha20-Poly1305" }
+</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>
+<pre class=js>
+{ kty: "AKP",
+alg: "MLKEM768-P256" }
+</pre>
+          </td>
+          <td>
+<pre class=js>
+{ name: "MLKEM768-P256" }
+</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>
+<pre class=js>
+{ kty: "AKP",
+alg: "MLKEM768-X25519" }
+</pre>
+          </td>
+          <td>
+<pre class=js>
+{ name: "MLKEM768-X25519" }
+</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>
+<pre class=js>
+{ kty: "AKP",
+alg: "MLKEM1024-P384" }
+</pre>
+          </td>
+          <td>
+<pre class=js>
+{ name: "MLKEM1024-P384" }
 </pre>
           </td>
         </tr>

--- a/index.html
+++ b/index.html
@@ -7651,21 +7651,9 @@ dictionary Argon2Params : Algorithm {
       </section>
       <section id="hybrid-kems-operations-import-key">
         <h5>Import Key</h5>
-        <div class=issue>
+        <div class=note>
           <p>
-            {{KeyFormat/"pkcs8"}} import is so far unspecified.
-            [[draft-ietf-lamps-pq-composite-kem]] defines
-            `OneAsymmetricKey.privateKey` as an `OCTET STRING` containing
-            `mlkemSeed || tradSK`, where `mlkemSeed` is the 64-byte ML-KEM
-            `d || z` seed and |tradSK| is the traditional private key encoding.
-          </p>
-          <p>
-            Importing this representation would produce a usable decapsulation
-            key, but we cannot recover the 32-byte seed used by
-            {{KeyFormat/"raw-seed"}} and {{KeyFormat/"jwk"}}.
-            We could require |extractable| to be `false` which would remove those
-            cases, or otherwise define that seed-based export formats fail for keys
-            that are not backed by a 32-byte seed.
+            TODO: {{KeyFormat/"pkcs8"}}.
           </p>
         </div>
         <ol>
@@ -8108,24 +8096,9 @@ dictionary Argon2Params : Algorithm {
       </section>
       <section id="hybrid-kems-operations-export-key">
         <h5>Export Key</h5>
-        <div class=issue>
+        <div class=note>
           <p>
-            {{KeyFormat/"pkcs8"}} export is so far unspecified.
-            [[draft-ietf-lamps-pq-composite-kem]] defines
-            `OneAsymmetricKey.privateKey` as an `OCTET STRING` containing
-            `mlkemSeed || tradSK`, where `mlkemSeed` is the 64-byte ML-KEM
-            `d || z` seed and |tradSK| is the traditional private key encoding.
-          </p>
-          <p>
-            Exporting this format can work for generated keys, or keys imported
-            with the 32-byte seed used by {{KeyFormat/"raw-seed"}} and
-            {{KeyFormat/"jwk"}}, provided the implementation can derive and
-            serialize the component private keys. For keys imported from
-            {{KeyFormat/"pkcs8"}}, we only have the LAMPS component
-            private-key representation. That representation is sufficient for
-            decapsulation and for {{KeyFormat/"pkcs8"}} re-export, but we cannot
-            export it as {{KeyFormat/"raw-seed"}} or {{KeyFormat/"jwk"}} unless
-            the key is backed by a 32-byte seed.
+            TODO: {{KeyFormat/"pkcs8"}}.
           </p>
         </div>
         <ol>

--- a/index.html
+++ b/index.html
@@ -104,6 +104,18 @@
         "href": "https://datatracker.ietf.org/doc/draft-ietf-hpke-hpke/",
         "publisher": "IETF"
       },
+      "draft-irtf-cfrg-hybrid-kems-09": {
+        "title": "Hybrid PQ/T Key Encapsulation Mechanisms",
+        "href": "https://www.ietf.org/archive/id/draft-irtf-cfrg-hybrid-kems-09.html",
+        "publisher": "IETF",
+        "date": "March 2026"
+      },
+      "draft-irtf-cfrg-concrete-hybrid-kems-03": {
+        "title": "Concrete Hybrid PQ/T Key Encapsulation Mechanisms",
+        "href": "https://www.ietf.org/archive/id/draft-irtf-cfrg-concrete-hybrid-kems-03.html",
+        "publisher": "IETF",
+        "date": "March 2026"
+      },
     },
   };
   </script>
@@ -114,8 +126,9 @@
     <p>
       This specification defines a number of post-quantum secure and
       modern cryptographic algorithms for the [[webcrypto | Web Cryptography API]],
-      namely ML-KEM, ML-DSA, SLH-DSA, AES-OCB, ChaCha20-Poly1305,
-      SHA-3, cSHAKE, TurboSHAKE, KangarooTwelve, KMAC, and Argon2.
+      namely ML-KEM, Hybrid KEMs, ML-DSA, SLH-DSA, AES-OCB,
+      ChaCha20-Poly1305, SHA-3, cSHAKE, TurboSHAKE, KangarooTwelve,
+      KMAC, and Argon2.
     </p>
   </section>
   <section id="sotd">
@@ -134,6 +147,7 @@
     </p>
     <ul>
       <li><a href="#ml-kem">ML-KEM</a> [[FIPS-203]]</li>
+      <li><a href="#hybrid-kems">Hybrid KEMs</a> [[draft-irtf-cfrg-concrete-hybrid-kems-03]]</li>
       <li><a href="#ml-dsa">ML-DSA</a> [[FIPS-204]]</li>
       <li><a href="#slh-dsa">SLH-DSA</a> [[FIPS-205]]</li>
       <li><a href="#aes-ocb">AES-OCB</a> [[RFC7253]]</li>
@@ -144,7 +158,7 @@
       <li><a href="#argon2">Argon2d, Argon2i, and Argon2id</a> [[RFC9106]]</li>
     </ul>
     <p>
-      To accommodate the usage of ML-KEM, and possibly future other KEMs,
+      To accommodate the usage of ML-KEM, Hybrid KEMs, and possibly future other KEMs,
       this proposal introduces functions for key encapsulation and decapsulation;
       <a href="#dfn-SubtleCrypto-method-encapsulateKey">`SubtleCrypto.encapsulateKey`</a>,
       <a href="#dfn-SubtleCrypto-method-encapsulateBits">`SubtleCrypto.encapsulateBits`</a>,
@@ -7351,6 +7365,740 @@ dictionary Argon2Params : Algorithm {
     </section>
   </section>
 
+  <section id="hybrid-kems">
+    <h3>Hybrid KEMs</h3>
+    <section id="hybrid-kems-description" class="informative">
+      <h4>Description</h4>
+      <p>
+        This describes using hybrid post-quantum/traditional key
+        encapsulation mechanisms for key encapsulation and decapsulation,
+        as specified by [[draft-irtf-cfrg-concrete-hybrid-kems-03]].
+      </p>
+    </section>
+    <section id="hybrid-kems-registration">
+      <h4>Registration</h4>
+      <p>
+        The <a data-cite="webcrypto#recognized-algorithm-name">recognized algorithm names</a> for
+        this algorithm are "`MLKEM768-P256`", "`MLKEM768-X25519`" and
+        "`MLKEM1024-P384`".
+      </p>
+      <table>
+        <thead>
+          <tr>
+            <th><a data-cite="webcrypto#supported-operations">Operation</a></th>
+            <th><a data-cite="webcrypto#algorithm-specific-params">Parameters</a></th>
+            <th><a data-cite="webcrypto#algorithm-result">Result</a></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>encapsulate</td>
+            <td>None</td>
+            <td>{{EncapsulatedBits}}</td>
+          </tr>
+          <tr>
+            <td>decapsulate</td>
+            <td>None</td>
+            <td>[= byte sequence =]</td>
+          </tr>
+          <tr>
+            <td>generateKey</td>
+            <td>None</td>
+            <td>{{CryptoKeyPair}}</td>
+          </tr>
+          <tr>
+            <td>importKey</td>
+            <td>None</td>
+            <td>{{CryptoKey}}</td>
+          </tr>
+          <tr>
+            <td>exportKey</td>
+            <td>None</td>
+            <td>object</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+    <section id="hybrid-kems-operations">
+      <h4>Operations</h4>
+      <section id="hybrid-kems-operations-encapsulate">
+        <h5>Encapsulate</h5>
+        <ol>
+          <li>
+            <p>
+              If the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot of
+              |key| is not {{KeyType/"public"}}, then [= exception/throw =] an {{InvalidAccessError}}.
+            </p>
+          </li>
+          <li>
+            <p>
+              Let |sharedKey| and |ciphertext| be the outputs that result
+              from performing the Encaps function for the hybrid
+              KEM instance indicated by the {{Algorithm/name}} member of
+              |algorithm| in Section 4 of
+              [[draft-irtf-cfrg-concrete-hybrid-kems-03]], using the key
+              represented by the <a data-cite="webcrypto#dfn-CryptoKey-slot-handle">`[[handle]]`</a>
+              internal slot of |key| as the |ek| input parameter.
+            </p>
+          </li>
+          <li>
+            <p>
+              If the Encaps function returned an error, return an {{OperationError}}.
+            </p>
+          </li>
+          <li>
+            <p>
+              Let |result| be a new {{EncapsulatedBits}}
+              dictionary.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the {{EncapsulatedBits/sharedKey}} attribute
+              of |result| to the result of [= ArrayBuffer/create | creating =]
+              an {{ArrayBuffer}} containing |sharedKey|.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the {{EncapsulatedBits/ciphertext}} attribute
+              of |result| to the result of [= ArrayBuffer/create | creating =]
+              an {{ArrayBuffer}} containing |ciphertext|.
+            </p>
+          </li>
+          <li>
+            <p>
+              Return |result|.
+            </p>
+          </li>
+        </ol>
+      </section>
+      <section id="hybrid-kems-operations-decapsulate">
+        <h5>Decapsulate</h5>
+        <ol>
+          <li>
+            <p>
+              If the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot of
+              |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
+            </p>
+          </li>
+          <li>
+            <p>
+              Let |sharedKey| be the output that results from performing
+              the Decaps function for the hybrid KEM instance
+              indicated by the {{Algorithm/name}} member of |algorithm| in
+              Section 4 of [[draft-irtf-cfrg-concrete-hybrid-kems-03]],
+              using the key represented by the <a data-cite="webcrypto#dfn-CryptoKey-slot-handle">`[[handle]]`</a>
+              internal slot of |key| as the |dk| input parameter, and
+              |ciphertext| as the |ct| input parameter.
+            </p>
+          </li>
+          <li>
+            <p>
+              If the Decaps function returned an error, return an {{OperationError}}.
+            </p>
+          </li>
+          <li>
+            <p>
+              Return |sharedKey|.
+            </p>
+          </li>
+        </ol>
+      </section>
+      <section id="hybrid-kems-operations-generate-key">
+        <h5>Generate Key</h5>
+        <ol>
+          <li>
+            <p>
+              If |usages| contains an entry which is not
+              one of "`encapsulateKey`", "`encapsulateBits`",
+              "`decapsulateKey`" or "`decapsulateBits`",
+              then [= exception/throw =] a
+              {{SyntaxError}}.
+            </p>
+          </li>
+          <li>
+            <p>
+              Generate a hybrid KEM key pair by performing the
+              GenerateKeyPair function described in Section 5.2 of
+              [[draft-irtf-cfrg-hybrid-kems-09]] with the hybrid
+              KEM instance indicated by the {{Algorithm/name}} member of
+              |normalizedAlgorithm|.
+            </p>
+          </li>
+          <li>
+            <p>
+              If the key generation step fails,
+              then [= exception/throw =] an
+              {{OperationError}}.
+            </p>
+          </li>
+          <li>
+            <p>
+              Let |algorithm| be a new {{KeyAlgorithm}} object.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the {{KeyAlgorithm/name}} attribute of
+              |algorithm| to the {{Algorithm/name}} attribute of
+              |normalizedAlgorithm|.
+            </p>
+          </li>
+          <li>
+            <p>
+              Let |publicKey| be a new {{CryptoKey}}
+              representing the encapsulation key of the generated key pair.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot of
+              |publicKey| to {{KeyType/"public"}}.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-algorithm">`[[algorithm]]`</a> internal
+              slot of |publicKey| to |algorithm|.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-extractable">`[[extractable]]`</a> internal
+              slot of |publicKey| to true.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-usages">`[[usages]]`</a> internal slot of
+              |publicKey| to be the
+              <a data-cite="webcrypto#concept-usage-intersection">usage intersection</a> of
+              |usages| and `[ "encapsulateKey", "encapsulateBits" ]`.
+            </p>
+          </li>
+          <li>
+            <p>
+              Let |privateKey| be a new {{CryptoKey}}
+              representing the decapsulation key of the generated key pair.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot of
+              |privateKey| to {{KeyType/"private"}}.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-algorithm">`[[algorithm]]`</a> internal
+              slot of |privateKey| to |algorithm|.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-extractable">`[[extractable]]`</a> internal
+              slot of |privateKey| to |extractable|.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-usages">`[[usages]]`</a> internal slot of
+              |privateKey| to be the
+              <a data-cite="webcrypto#concept-usage-intersection">usage intersection</a> of
+              |usages| and `[ "decapsulateKey", "decapsulateBits" ]`.
+            </p>
+          </li>
+          <li>
+            <p>
+              Let |result| be a new {{CryptoKeyPair}}
+              dictionary.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the {{CryptoKeyPair/publicKey}} attribute
+              of |result| to be |publicKey|.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the {{CryptoKeyPair/privateKey}} attribute
+              of |result| to be |privateKey|.
+            </p>
+          </li>
+          <li>
+            <p>
+              Return |result|.
+            </p>
+          </li>
+        </ol>
+      </section>
+      <section id="hybrid-kems-operations-import-key">
+        <h5>Import Key</h5>
+        <div class=note>
+          <p>
+            TODO: {{KeyFormat/"spki"}} and {{KeyFormat/"pkcs8"}}.
+          </p>
+        </div>
+        <ol>
+          <li>
+            <p>Let |keyData| be the key data to be imported.</p>
+          </li>
+          <li>
+            <dl class="switch">
+              <dt>If |format| is {{KeyFormat/"raw-public"}}:</dt>
+              <dd>
+                <ol>
+                  <li>
+                    <p>
+                      If |usages| contains an entry which is not
+                      "`encapsulateKey`" or "`encapsulateBits`"
+                      then [= exception/throw =] a
+                      {{SyntaxError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |data| be |keyData|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the length in bytes of |data| is not the raw public key
+                      length, `Nek`, for the hybrid KEM instance
+                      indicated by the {{Algorithm/name}} member of
+                      |normalizedAlgorithm| in Section 4 of
+                      [[draft-irtf-cfrg-concrete-hybrid-kems-03]], then
+                      [= exception/throw =] a {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |key| be a new {{CryptoKey}}
+                      that represents the hybrid KEM public key data in |data|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot
+                      of |key| to {{KeyType/"public"}}
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |algorithm| be a new {{KeyAlgorithm}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the {{KeyAlgorithm/name}} attribute of
+                      |algorithm| to the {{Algorithm/name}} attribute of
+                      |normalizedAlgorithm|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-algorithm">`[[algorithm]]`</a>
+                      internal slot of |key| to |algorithm|.
+                    </p>
+                  </li>
+                </ol>
+              </dd>
+              <dt>If |format| is {{KeyFormat/"raw-seed"}}:</dt>
+              <dd>
+                <ol>
+                  <li>
+                    <p>
+                      If |usages| contains an entry which is not
+                      "`decapsulateKey`" or "`decapsulateBits`"
+                      then [= exception/throw =] a
+                      {{SyntaxError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |data| be |keyData|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the length in bits of |data| is not 256
+                      then [= exception/throw =] a
+                      {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |keyPair| be the result of performing the
+                      DeriveKeyPair function described in Section 5.5 of
+                      [[draft-irtf-cfrg-hybrid-kems-09]] with the
+                      hybrid KEM instance indicated by the {{Algorithm/name}}
+                      member of |normalizedAlgorithm|, using |data| as the
+                      |seed| input parameter.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the DeriveKeyPair function returned an error,
+                      then [= exception/throw =] an {{OperationError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |key| be a new {{CryptoKey}}
+                      that represents the hybrid KEM private key identified by
+                      the decapsulation key of |keyPair|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot
+                      of |key| to {{KeyType/"private"}}
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |algorithm| be a new {{KeyAlgorithm}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the {{KeyAlgorithm/name}} attribute of
+                      |algorithm| to the {{Algorithm/name}} attribute of
+                      |normalizedAlgorithm|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-algorithm">`[[algorithm]]`</a>
+                      internal slot of |key| to |algorithm|.
+                    </p>
+                  </li>
+                </ol>
+              </dd>
+              <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
+              <dd>
+                <ol>
+                  <li>
+                    <dl class="switch">
+                      <dt>If |keyData| is a {{JsonWebKey}} dictionary:</dt>
+                      <dd><p>Let |jwk| equal |keyData|.</p></dd>
+                      <dt>Otherwise:</dt>
+                      <dd><p>[= exception/Throw =] a {{DataError}}.</p></dd>
+                    </dl>
+                  </li>
+                  <li>
+                    <p>
+                      If the {{JsonWebKey/priv}} field of |jwk| is present
+                      and if |usages| contains an entry which is not
+                      "`decapsulateKey`" or "`decapsulateBits`"
+                      then [= exception/throw =] a
+                      {{SyntaxError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the {{JsonWebKey/priv}} field of |jwk| is not present
+                      and if |usages| contains an entry which is not
+                      "`encapsulateKey`" or "`encapsulateBits`"
+                      then [= exception/throw =] a
+                      {{SyntaxError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the {{JsonWebKey/kty}} field of |jwk| is not
+                      "`AKP`",
+                      then [= exception/throw =] a
+                      {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the {{JsonWebKey/alg}} field of |jwk| is not
+                      equal to the {{Algorithm/name}} member of
+                      |normalizedAlgorithm|, then [= exception/throw =] a
+                      {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If |usages| is non-empty and the {{JsonWebKey/use}} field of |jwk| is present
+                      and is not equal to "`enc`", then [= exception/throw =] a
+                      {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the {{JsonWebKey/key_ops}} field of |jwk| is present, and
+                      is invalid according to the requirements of JSON Web
+                      Key [[JWK]], or it does not contain all of the specified |usages|
+                      values,
+                      then [= exception/throw =] a
+                      {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the {{JsonWebKey/ext}} field of |jwk| is present and
+                      has the value false and |extractable| is true,
+                      then [= exception/throw =] a
+                      {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <dl class="switch">
+                      <dt>If the {{JsonWebKey/priv}} field of |jwk| is present:</dt>
+                      <dd>
+                        <ol>
+                          <li>
+                            <p>
+                              If the {{JsonWebKey/priv}} attribute of |jwk|
+                              does not contain a valid base64url encoded
+                              32-byte seed representing a hybrid KEM private key,
+                              then [= exception/throw =] a {{DataError}}.
+                            </p>
+                          </li>
+                          <li>
+                            <p>
+                              Let |key| be a new {{CryptoKey}} object that represents the
+                              hybrid KEM private key identified by interpreting the
+                              {{JsonWebKey/priv}} attribute of |jwk|
+                              as a base64url encoded seed.
+                            </p>
+                          </li>
+                          <li>
+                            <p>
+                              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a>
+                              internal slot of |key| to {{KeyType/"private"}}.
+                            </p>
+                          </li>
+                          <li>
+                            <p>
+                              If the {{JsonWebKey/pub}} attribute of |jwk|
+                              does not contain the base64url encoded public key
+                              representing the hybrid KEM public key
+                              corresponding to |key|,
+                              then [= exception/throw =] a {{DataError}}.
+                            </p>
+                          </li>
+                        </ol>
+                      </dd>
+                      <dt>Otherwise:</dt>
+                      <dd>
+                        <ol>
+                          <li>
+                            <p>
+                              If the {{JsonWebKey/pub}} attribute of |jwk|
+                              does not contain a valid base64url encoded raw
+                              public key whose length is `Nek` for the
+                              hybrid KEM instance indicated by the
+                              {{Algorithm/name}} member of
+                              |normalizedAlgorithm| in Section 4 of
+                              [[draft-irtf-cfrg-concrete-hybrid-kems-03]],
+                              then [= exception/throw =] a {{DataError}}.
+                            </p>
+                          </li>
+                          <li>
+                            <p>
+                              Let |key| be a new {{CryptoKey}} object that represents the
+                              hybrid KEM public key identified by interpreting the
+                              {{JsonWebKey/pub}} attribute of |jwk|
+                              as a base64url encoded public key.
+                            </p>
+                          </li>
+                          <li>
+                            <p>
+                              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a>
+                              internal slot of |key| to {{KeyType/"public"}}.
+                            </p>
+                          </li>
+                        </ol>
+                      </dd>
+                    </dl>
+                  </li>
+                  <li>
+                    <p>
+                      Let |algorithm| be a new instance of a {{KeyAlgorithm}} object.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the {{KeyAlgorithm/name}} attribute of
+                      |algorithm| to the {{Algorithm/name}} member of |normalizedAlgorithm|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-algorithm">`[[algorithm]]`</a>
+                      internal slot of |key| to |algorithm|.
+                    </p>
+                  </li>
+                </ol>
+              </dd>
+              <dt>Otherwise:</dt>
+              <dd>
+                [= exception/throw =] a
+                {{NotSupportedError}}.
+              </dd>
+            </dl>
+          </li>
+          <li>
+            <p>
+              Return |key|.
+            </p>
+          </li>
+        </ol>
+      </section>
+      <section id="hybrid-kems-operations-export-key">
+        <h5>Export Key</h5>
+        <ol>
+          <li>
+            <p>
+              Let |key| be the {{CryptoKey}} to be
+              exported.
+            </p>
+          </li>
+          <li>
+            <p>
+              If the underlying cryptographic key material represented by the <a data-cite="webcrypto#dfn-CryptoKey-slot-handle">`[[handle]]`</a> internal slot of |key|
+              cannot be accessed, then [= exception/throw =] an {{OperationError}}.
+            </p>
+          </li>
+          <li>
+            <dl class="switch">
+              <dt>If |format| is {{KeyFormat/"raw-public"}}:</dt>
+              <dd>
+                <ol>
+                  <li>
+                    <p>
+                      If the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot
+                      of |key| is not {{KeyType/"public"}}, then [= exception/throw =] an {{InvalidAccessError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |data| be a [= byte sequence =] containing
+                      the raw octets of the key represented by the <a data-cite="webcrypto#dfn-CryptoKey-slot-handle">`[[handle]]`</a> internal slot of
+                      |key|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |result| be |data|.
+                    </p>
+                  </li>
+                </ol>
+              </dd>
+              <dt>If |format| is {{KeyFormat/"raw-seed"}}:</dt>
+              <dd>
+                <ol>
+                  <li>
+                    <p>
+                      If the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot
+                      of |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |data| be a [= byte sequence =] containing the 32-byte seed represented by
+                      the <a data-cite="webcrypto#dfn-CryptoKey-slot-handle">`[[handle]]`</a>
+                      internal slot of |key|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |result| be |data|.
+                    </p>
+                  </li>
+                </ol>
+              </dd>
+              <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
+              <dd>
+                <ol>
+                  <li>
+                    <p>
+                      Let |jwk| be a new {{JsonWebKey}}
+                      dictionary.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |keyAlgorithm| be the <a data-cite="webcrypto#dfn-CryptoKey-slot-algorithm">`[[algorithm]]`</a> internal slot of |key|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the `kty` attribute of |jwk| to
+                      "`AKP`".
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the `alg` attribute of |jwk| to the
+                      {{Algorithm/name}} member of |keyAlgorithm|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the {{JsonWebKey/pub}} attribute of |jwk|
+                      to the base64url encoded public key corresponding
+                      to the <a data-cite="webcrypto#dfn-CryptoKey-slot-handle">`[[handle]]`</a>
+                      internal slot of |key|.
+                    </p>
+                  </li>
+                  <li>
+                    <dl class="switch">
+                      <dt>
+                        If the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot
+                        of |key| is {{KeyType/"private"}}:
+                      </dt>
+                      <dd>
+                        Set the {{JsonWebKey/priv}} attribute of |jwk|
+                        to the base64url encoded 32-byte seed represented by
+                        the <a data-cite="webcrypto#dfn-CryptoKey-slot-handle">`[[handle]]`</a>
+                        internal slot of |key|.
+                      </dd>
+                    </dl>
+                  </li>
+                  <li>
+                    <p>
+                      Set the `key_ops` attribute of |jwk| to the {{CryptoKey/usages}} attribute of |key|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the `ext` attribute of |jwk| to the <a data-cite="webcrypto#dfn-CryptoKey-slot-extractable">`[[extractable]]`</a> internal slot
+                      of |key|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |result| be |jwk|.
+                    </p>
+                  </li>
+                </ol>
+              </dd>
+              <dt>Otherwise:</dt>
+              <dd>
+                <p>
+                  [= exception/throw =] a
+                  {{NotSupportedError}}.
+                </p>
+              </dd>
+            </dl>
+          </li>
+          <li>
+            <p>
+              Return |result|.
+            </p>
+          </li>
+        </ol>
+      </section>
+    </section>
+  </section>
+
   <section id="iana-section">
     <h2>IANA Considerations</h2>
     <section id="iana-section-jws-jwa">
@@ -7505,6 +8253,30 @@ dictionary Argon2Params : Algorithm {
         <li>Change Controller: W3C Web Application Security Working Group</li>
         <li>Specification Document(s): [[ This Document ]]</li>
       </ul>
+      <ul>
+        <li>Algorithm Name: "MLKEM768-P256"</li>
+        <li>Algorithm Description: Hybrid KEM using ML-KEM-768 and P-256</li>
+        <li>Algorithm Usage Location(s): "JWK"</li>
+        <li>JOSE Implementation Requirements: Optional</li>
+        <li>Change Controller: W3C Web Application Security Working Group</li>
+        <li>Specification Document(s): [[ This Document ]]</li>
+      </ul>
+      <ul>
+        <li>Algorithm Name: "MLKEM768-X25519"</li>
+        <li>Algorithm Description: Hybrid KEM using ML-KEM-768 and X25519</li>
+        <li>Algorithm Usage Location(s): "JWK"</li>
+        <li>JOSE Implementation Requirements: Optional</li>
+        <li>Change Controller: W3C Web Application Security Working Group</li>
+        <li>Specification Document(s): [[ This Document ]]</li>
+      </ul>
+      <ul>
+        <li>Algorithm Name: "MLKEM1024-P384"</li>
+        <li>Algorithm Description: Hybrid KEM using ML-KEM-1024 and P-384</li>
+        <li>Algorithm Usage Location(s): "JWK"</li>
+        <li>JOSE Implementation Requirements: Optional</li>
+        <li>Change Controller: W3C Web Application Security Working Group</li>
+        <li>Specification Document(s): [[ This Document ]]</li>
+      </ul>
     </section>
     <section id="iana-section-key-operations">
       <h3>JSON Web Key Operations</h3>
@@ -7576,6 +8348,11 @@ dictionary Argon2Params : Algorithm {
         post-quantum/traditional (PQ/T) key establishment as used in
         protocols like [[draft-ietf-hpke-hpke]] and its PQ and PQ/T
         algorithms [[draft-ietf-hpke-pq]].
+      </li>
+      <li>
+        <a href="#hybrid-kems">Hybrid KEMs</a> provide
+        post-quantum/traditional KEM instances that combine ML-KEM with
+        P-256, X25519, or P-384 [[draft-irtf-cfrg-concrete-hybrid-kems-03]].
       </li>
       <li>
         <a href="#ml-dsa">ML-DSA</a> is the primary post-quantum digital
@@ -7760,6 +8537,45 @@ alg: "C20P" }
           <td>
 <pre class=js>
 { name: "ChaCha20-Poly1305" }
+</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>
+<pre class=js>
+{ kty: "AKP",
+alg: "MLKEM768-P256" }
+</pre>
+          </td>
+          <td>
+<pre class=js>
+{ name: "MLKEM768-P256" }
+</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>
+<pre class=js>
+{ kty: "AKP",
+alg: "MLKEM768-X25519" }
+</pre>
+          </td>
+          <td>
+<pre class=js>
+{ name: "MLKEM768-X25519" }
+</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>
+<pre class=js>
+{ kty: "AKP",
+alg: "MLKEM1024-P384" }
+</pre>
+          </td>
+          <td>
+<pre class=js>
+{ name: "MLKEM1024-P384" }
 </pre>
           </td>
         </tr>

--- a/index.html
+++ b/index.html
@@ -7402,6 +7402,11 @@ dictionary Argon2Params : Algorithm {
             <td>[= byte sequence =]</td>
           </tr>
           <tr>
+            <td>get shared key length</td>
+            <td>None</td>
+            <td>Integer</td>
+          </tr>
+          <tr>
             <td>generateKey</td>
             <td>None</td>
             <td>{{CryptoKeyPair}}</td>
@@ -7511,6 +7516,16 @@ dictionary Argon2Params : Algorithm {
           <li>
             <p>
               Return |sharedKey|.
+            </p>
+          </li>
+        </ol>
+      </section>
+      <section id="hybrid-kems-operations-get-shared-key-length">
+        <h5>Get shared key length</h5>
+        <ol>
+          <li>
+            <p>
+              Return 256.
             </p>
           </li>
         </ol>

--- a/index.html
+++ b/index.html
@@ -7651,9 +7651,21 @@ dictionary Argon2Params : Algorithm {
       </section>
       <section id="hybrid-kems-operations-import-key">
         <h5>Import Key</h5>
-        <div class=note>
+        <div class=issue>
           <p>
-            TODO: {{KeyFormat/"pkcs8"}}.
+            {{KeyFormat/"pkcs8"}} import is so far unspecified.
+            [[draft-ietf-lamps-pq-composite-kem]] defines
+            `OneAsymmetricKey.privateKey` as an `OCTET STRING` containing
+            `mlkemSeed || tradSK`, where `mlkemSeed` is the 64-byte ML-KEM
+            `d || z` seed and |tradSK| is the traditional private key encoding.
+          </p>
+          <p>
+            Importing this representation would produce a usable decapsulation
+            key, but we cannot recover the 32-byte seed used by
+            {{KeyFormat/"raw-seed"}} and {{KeyFormat/"jwk"}}.
+            We could require |extractable| to be `false` which would remove those
+            cases, or otherwise define that seed-based export formats fail for keys
+            that are not backed by a 32-byte seed.
           </p>
         </div>
         <ol>
@@ -8096,9 +8108,24 @@ dictionary Argon2Params : Algorithm {
       </section>
       <section id="hybrid-kems-operations-export-key">
         <h5>Export Key</h5>
-        <div class=note>
+        <div class=issue>
           <p>
-            TODO: {{KeyFormat/"pkcs8"}}.
+            {{KeyFormat/"pkcs8"}} export is so far unspecified.
+            [[draft-ietf-lamps-pq-composite-kem]] defines
+            `OneAsymmetricKey.privateKey` as an `OCTET STRING` containing
+            `mlkemSeed || tradSK`, where `mlkemSeed` is the 64-byte ML-KEM
+            `d || z` seed and |tradSK| is the traditional private key encoding.
+          </p>
+          <p>
+            Exporting this format can work for generated keys, or keys imported
+            with the 32-byte seed used by {{KeyFormat/"raw-seed"}} and
+            {{KeyFormat/"jwk"}}, provided the implementation can derive and
+            serialize the component private keys. For keys imported from
+            {{KeyFormat/"pkcs8"}}, we only have the LAMPS component
+            private-key representation. That representation is sufficient for
+            decapsulation and for {{KeyFormat/"pkcs8"}} re-export, but we cannot
+            export it as {{KeyFormat/"raw-seed"}} or {{KeyFormat/"jwk"}} unless
+            the key is backed by a 32-byte seed.
           </p>
         </div>
         <ol>

--- a/index.html
+++ b/index.html
@@ -7419,6 +7419,16 @@ dictionary Argon2Params : Algorithm {
         </tbody>
       </table>
     </section>
+    <section id="hybrid-kems-jwk">
+      <h4>JSON Web Key Representation</h4>
+      <p>
+        Hybrid KEM keys use the "AKP" (Algorithm Key Pair) key type defined in [[draft-ietf-cose-dilithium-08]]
+        for JWK representation. The "alg" (algorithm) parameter identifies the specific hybrid KEM instance.
+        The public key is carried in the "pub" parameter. If a private key is included, it is represented
+        using the "priv" parameter. When expressed in JWK, all key parameters are base64url encoded.
+      </p>
+    </section>
+
     <section id="hybrid-kems-operations">
       <h4>Operations</h4>
       <section id="hybrid-kems-operations-encapsulate">
@@ -7816,10 +7826,21 @@ dictionary Argon2Params : Algorithm {
                   </li>
                   <li>
                     <p>
-                      If the {{JsonWebKey/alg}} field of |jwk| is not
-                      equal to the {{Algorithm/name}} member of
-                      |normalizedAlgorithm|, then [= exception/throw =] a
+                      If the {{JsonWebKey/alg}} field of |jwk| is not present,
+                      or its value does not identify the hybrid KEM instance
+                      indicated by the {{Algorithm/name}} member of
+                      |normalizedAlgorithm|,
+                      then [= exception/throw =] a
                       {{DataError}}.
+                    </p>
+                    <p class="note">
+                      The "alg" values registered in the
+                      IANA JSON Web Signature and Encryption Algorithms registry
+                      for the hybrid KEM instances defined by this specification
+                      are `MLKEM768-P256`, `MLKEM768-X25519`, and
+                      `MLKEM1024-P384`. Implementations should also accept other
+                      values from this registry that identify an algorithm
+                      utilizing the same hybrid KEM instance.
                     </p>
                   </li>
                   <li>

--- a/index.html
+++ b/index.html
@@ -94,11 +94,6 @@
         "href": "https://csrc.nist.gov/projects/computer-security-objects-register/algorithm-registration",
         "publisher": "NIST"
       },
-      "draft-ietf-lamps-pq-composite-kem": {
-        "title": "Composite ML-KEM for use in X.509 Public Key Infrastructure",
-        "href": "https://datatracker.ietf.org/doc/draft-ietf-lamps-pq-composite-kem/",
-        "publisher": "IETF"
-      },
       "draft-ietf-hpke-pq": {
         "title": "Post-Quantum Hybrid Key Encapsulation Mechanisms for HPKE",
         "href": "https://datatracker.ietf.org/doc/draft-ietf-hpke-pq/",
@@ -7653,7 +7648,7 @@ dictionary Argon2Params : Algorithm {
         <h5>Import Key</h5>
         <div class=note>
           <p>
-            TODO: {{KeyFormat/"pkcs8"}}.
+            TODO: {{KeyFormat/"spki"}} and {{KeyFormat/"pkcs8"}}.
           </p>
         </div>
         <ol>
@@ -7662,123 +7657,6 @@ dictionary Argon2Params : Algorithm {
           </li>
           <li>
             <dl class="switch">
-              <dt>If |format| is {{KeyFormat/"spki"}}:</dt>
-              <dd>
-                <ol>
-                  <li>
-                    <p>
-                      If |usages| contains an entry which is not
-                      "`encapsulateKey`" or "`encapsulateBits`"
-                      then [= exception/throw =] a
-                      {{SyntaxError}}.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Let |spki| be the result of running the
-                      <a data-cite="webcrypto#concept-parse-a-spki">parse a subjectPublicKeyInfo</a>
-                      algorithm over |keyData|.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      If an error occurred while parsing,
-                      then [= exception/throw =] a
-                      {{DataError}}.
-                    </p>
-                  </li>
-                  <li>
-                    <dl class="switch">
-                      <dt>If the {{Algorithm/name}} member of |normalizedAlgorithm| is "`MLKEM768-P256`":</dt>
-                      <dd>
-                        <p>
-                          Let |expectedOid| be `id-MLKEM768-ECDH-P256-SHA3-256` (1.3.6.1.5.5.7.6.59).
-                        </p>
-                      </dd>
-                      <dt>If the {{Algorithm/name}} member of |normalizedAlgorithm| is "`MLKEM768-X25519`":</dt>
-                      <dd>
-                        <p>
-                          Let |expectedOid| be `id-MLKEM768-X25519-SHA3-256` (1.3.6.1.5.5.7.6.58).
-                        </p>
-                      </dd>
-                      <dt>If the {{Algorithm/name}} member of |normalizedAlgorithm| is "`MLKEM1024-P384`":</dt>
-                      <dd>
-                        <p>
-                          Let |expectedOid| be `id-MLKEM1024-ECDH-P384-SHA3-256` (1.3.6.1.5.5.7.6.63).
-                        </p>
-                      </dd>
-                      <dt>Otherwise:</dt>
-                      <dd>
-                        <p>
-                          [= exception/throw =] a {{NotSupportedError}}.
-                        </p>
-                      </dd>
-                    </dl>
-                  </li>
-                  <li>
-                    <p>
-                      If the `algorithm` object identifier field of the
-                      `algorithm` AlgorithmIdentifier field of |spki| is
-                      not equal to |expectedOid|,
-                      then [= exception/throw =] a {{DataError}}.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      If the `parameters` field of the `algorithm`
-                      AlgorithmIdentifier field of |spki| is present,
-                      then [= exception/throw =] a
-                      {{DataError}}.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Let |publicKey| be the hybrid KEM public key identified by
-                      the `subjectPublicKey` field of |spki|.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      If the length in bytes of |publicKey| is not the raw public key
-                      length, `Nek`, for the hybrid KEM instance
-                      indicated by the {{Algorithm/name}} member of
-                      |normalizedAlgorithm| in Section 4 of
-                      [[draft-irtf-cfrg-concrete-hybrid-kems-03]], then
-                      [= exception/throw =] a {{DataError}}.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Let |key| be a new {{CryptoKey}}
-                      that represents |publicKey|.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot
-                      of |key| to {{KeyType/"public"}}
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Let |algorithm| be a new {{KeyAlgorithm}}.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Set the {{KeyAlgorithm/name}} attribute of
-                      |algorithm| to the {{Algorithm/name}} attribute of
-                      |normalizedAlgorithm|.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-algorithm">`[[algorithm]]`</a>
-                      internal slot of |key| to |algorithm|.
-                    </p>
-                  </li>
-                </ol>
-              </dd>
               <dt>If |format| is {{KeyFormat/"raw-public"}}:</dt>
               <dd>
                 <ol>
@@ -8096,11 +7974,6 @@ dictionary Argon2Params : Algorithm {
       </section>
       <section id="hybrid-kems-operations-export-key">
         <h5>Export Key</h5>
-        <div class=note>
-          <p>
-            TODO: {{KeyFormat/"pkcs8"}}.
-          </p>
-        </div>
         <ol>
           <li>
             <p>
@@ -8116,85 +7989,6 @@ dictionary Argon2Params : Algorithm {
           </li>
           <li>
             <dl class="switch">
-              <dt>If |format| is {{KeyFormat/"spki"}}:</dt>
-              <dd>
-                <ol>
-                  <li>
-                    <p>
-                      If the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot
-                      of |key| is not {{KeyType/"public"}}, then [= exception/throw =] an {{InvalidAccessError}}.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Let |keyAlgorithm| be the <a data-cite="webcrypto#dfn-CryptoKey-slot-algorithm">`[[algorithm]]`</a> internal slot of |key|.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Let |keyData| be a [= byte sequence =] containing
-                      the raw octets of the key represented by the <a data-cite="webcrypto#dfn-CryptoKey-slot-handle">`[[handle]]`</a> internal slot of
-                      |key|.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Let |data| be an instance of the `SubjectPublicKeyInfo`
-                      ASN.1 structure defined in [[RFC5280]]
-                      with the following properties:
-                    </p>
-                    <ul>
-                      <li>
-                        <p>
-                          Set the |algorithm| field to an
-                          `AlgorithmIdentifier` ASN.1 type with the following
-                          properties:
-                        </p>
-                        <ul>
-                          <li>
-                            <dl class="switch">
-                              <dt>If the {{Algorithm/name}} member of |keyAlgorithm| is "`MLKEM768-P256`":</dt>
-                              <dd>
-                                <p>
-                                  Set the |algorithm| object identifier to the `id-MLKEM768-ECDH-P256-SHA3-256` (1.3.6.1.5.5.7.6.59) OID.
-                                </p>
-                              </dd>
-                              <dt>If the {{Algorithm/name}} member of |keyAlgorithm| is "`MLKEM768-X25519`":</dt>
-                              <dd>
-                                <p>
-                                  Set the |algorithm| object identifier to the `id-MLKEM768-X25519-SHA3-256` (1.3.6.1.5.5.7.6.58) OID.
-                                </p>
-                              </dd>
-                              <dt>If the {{Algorithm/name}} member of |keyAlgorithm| is "`MLKEM1024-P384`":</dt>
-                              <dd>
-                                <p>
-                                  Set the |algorithm| object identifier to the `id-MLKEM1024-ECDH-P384-SHA3-256` (1.3.6.1.5.5.7.6.63) OID.
-                                </p>
-                              </dd>
-                              <dt>Otherwise:</dt>
-                              <dd>
-                                <p>
-                                  [= exception/throw =] a {{NotSupportedError}}.
-                                </p>
-                              </dd>
-                            </dl>
-                          </li>
-                        </ul>
-                      </li>
-                      <li>
-                        <p>
-                          Set the |subjectPublicKey| field to |keyData|.
-                        </p>
-                      </li>
-                    </ul>
-                  </li>
-                  <li>
-                    <p>
-                      Let |result| be the result of DER-encoding |data|.
-                    </p>
-                  </li>
-                </ol>
-              </dd>
               <dt>If |format| is {{KeyFormat/"raw-public"}}:</dt>
               <dd>
                 <ol>
@@ -9110,36 +8904,6 @@ alg: "K256" }
           </td>
           <td>
             [[CSOR]], [[RFC9935]]
-          </td>
-        </tr>
-        <tr>
-          <td>id-MLKEM768-X25519-SHA3-256 (1.3.6.1.5.5.7.6.58)</td>
-          <td>BIT STRING</td>
-          <td>
-            "`MLKEM768-X25519`"
-          </td>
-          <td>
-            [[draft-ietf-lamps-pq-composite-kem]]
-          </td>
-        </tr>
-        <tr>
-          <td>id-MLKEM768-ECDH-P256-SHA3-256 (1.3.6.1.5.5.7.6.59)</td>
-          <td>BIT STRING</td>
-          <td>
-            "`MLKEM768-P256`"
-          </td>
-          <td>
-            [[draft-ietf-lamps-pq-composite-kem]]
-          </td>
-        </tr>
-        <tr>
-          <td>id-MLKEM1024-ECDH-P384-SHA3-256 (1.3.6.1.5.5.7.6.63)</td>
-          <td>BIT STRING</td>
-          <td>
-            "`MLKEM1024-P384`"
-          </td>
-          <td>
-            [[draft-ietf-lamps-pq-composite-kem]]
           </td>
         </tr>
         <tr>

--- a/index.html
+++ b/index.html
@@ -7427,7 +7427,7 @@ dictionary Argon2Params : Algorithm {
     <section id="hybrid-kems-jwk">
       <h4>JSON Web Key Representation</h4>
       <p>
-        Hybrid KEM keys use the "AKP" (Algorithm Key Pair) key type defined in [[draft-ietf-cose-dilithium-08]]
+        Hybrid KEM keys use the "AKP" (Algorithm Key Pair) key type defined in [[RFC9964]]
         for JWK representation. The "alg" (algorithm) parameter identifies the specific hybrid KEM instance.
         The public key is carried in the "pub" parameter. If a private key is included, it is represented
         using the "priv" parameter. When expressed in JWK, all key parameters are base64url encoded.

--- a/index.html
+++ b/index.html
@@ -94,6 +94,11 @@
         "href": "https://csrc.nist.gov/projects/computer-security-objects-register/algorithm-registration",
         "publisher": "NIST"
       },
+      "draft-ietf-lamps-pq-composite-kem": {
+        "title": "Composite ML-KEM for use in X.509 Public Key Infrastructure",
+        "href": "https://datatracker.ietf.org/doc/draft-ietf-lamps-pq-composite-kem/",
+        "publisher": "IETF"
+      },
       "draft-ietf-hpke-pq": {
         "title": "Post-Quantum Hybrid Key Encapsulation Mechanisms for HPKE",
         "href": "https://datatracker.ietf.org/doc/draft-ietf-hpke-pq/",
@@ -7648,7 +7653,7 @@ dictionary Argon2Params : Algorithm {
         <h5>Import Key</h5>
         <div class=note>
           <p>
-            TODO: {{KeyFormat/"spki"}} and {{KeyFormat/"pkcs8"}}.
+            TODO: {{KeyFormat/"pkcs8"}}.
           </p>
         </div>
         <ol>
@@ -7657,6 +7662,123 @@ dictionary Argon2Params : Algorithm {
           </li>
           <li>
             <dl class="switch">
+              <dt>If |format| is {{KeyFormat/"spki"}}:</dt>
+              <dd>
+                <ol>
+                  <li>
+                    <p>
+                      If |usages| contains an entry which is not
+                      "`encapsulateKey`" or "`encapsulateBits`"
+                      then [= exception/throw =] a
+                      {{SyntaxError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |spki| be the result of running the
+                      <a data-cite="webcrypto#concept-parse-a-spki">parse a subjectPublicKeyInfo</a>
+                      algorithm over |keyData|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If an error occurred while parsing,
+                      then [= exception/throw =] a
+                      {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <dl class="switch">
+                      <dt>If the {{Algorithm/name}} member of |normalizedAlgorithm| is "`MLKEM768-P256`":</dt>
+                      <dd>
+                        <p>
+                          Let |expectedOid| be `id-MLKEM768-ECDH-P256-SHA3-256` (1.3.6.1.5.5.7.6.59).
+                        </p>
+                      </dd>
+                      <dt>If the {{Algorithm/name}} member of |normalizedAlgorithm| is "`MLKEM768-X25519`":</dt>
+                      <dd>
+                        <p>
+                          Let |expectedOid| be `id-MLKEM768-X25519-SHA3-256` (1.3.6.1.5.5.7.6.58).
+                        </p>
+                      </dd>
+                      <dt>If the {{Algorithm/name}} member of |normalizedAlgorithm| is "`MLKEM1024-P384`":</dt>
+                      <dd>
+                        <p>
+                          Let |expectedOid| be `id-MLKEM1024-ECDH-P384-SHA3-256` (1.3.6.1.5.5.7.6.63).
+                        </p>
+                      </dd>
+                      <dt>Otherwise:</dt>
+                      <dd>
+                        <p>
+                          [= exception/throw =] a {{NotSupportedError}}.
+                        </p>
+                      </dd>
+                    </dl>
+                  </li>
+                  <li>
+                    <p>
+                      If the `algorithm` object identifier field of the
+                      `algorithm` AlgorithmIdentifier field of |spki| is
+                      not equal to |expectedOid|,
+                      then [= exception/throw =] a {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the `parameters` field of the `algorithm`
+                      AlgorithmIdentifier field of |spki| is present,
+                      then [= exception/throw =] a
+                      {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |publicKey| be the hybrid KEM public key identified by
+                      the `subjectPublicKey` field of |spki|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the length in bytes of |publicKey| is not the raw public key
+                      length, `Nek`, for the hybrid KEM instance
+                      indicated by the {{Algorithm/name}} member of
+                      |normalizedAlgorithm| in Section 4 of
+                      [[draft-irtf-cfrg-concrete-hybrid-kems-03]], then
+                      [= exception/throw =] a {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |key| be a new {{CryptoKey}}
+                      that represents |publicKey|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot
+                      of |key| to {{KeyType/"public"}}
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |algorithm| be a new {{KeyAlgorithm}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the {{KeyAlgorithm/name}} attribute of
+                      |algorithm| to the {{Algorithm/name}} attribute of
+                      |normalizedAlgorithm|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-algorithm">`[[algorithm]]`</a>
+                      internal slot of |key| to |algorithm|.
+                    </p>
+                  </li>
+                </ol>
+              </dd>
               <dt>If |format| is {{KeyFormat/"raw-public"}}:</dt>
               <dd>
                 <ol>
@@ -7974,6 +8096,11 @@ dictionary Argon2Params : Algorithm {
       </section>
       <section id="hybrid-kems-operations-export-key">
         <h5>Export Key</h5>
+        <div class=note>
+          <p>
+            TODO: {{KeyFormat/"pkcs8"}}.
+          </p>
+        </div>
         <ol>
           <li>
             <p>
@@ -7989,6 +8116,85 @@ dictionary Argon2Params : Algorithm {
           </li>
           <li>
             <dl class="switch">
+              <dt>If |format| is {{KeyFormat/"spki"}}:</dt>
+              <dd>
+                <ol>
+                  <li>
+                    <p>
+                      If the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot
+                      of |key| is not {{KeyType/"public"}}, then [= exception/throw =] an {{InvalidAccessError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |keyAlgorithm| be the <a data-cite="webcrypto#dfn-CryptoKey-slot-algorithm">`[[algorithm]]`</a> internal slot of |key|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |keyData| be a [= byte sequence =] containing
+                      the raw octets of the key represented by the <a data-cite="webcrypto#dfn-CryptoKey-slot-handle">`[[handle]]`</a> internal slot of
+                      |key|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |data| be an instance of the `SubjectPublicKeyInfo`
+                      ASN.1 structure defined in [[RFC5280]]
+                      with the following properties:
+                    </p>
+                    <ul>
+                      <li>
+                        <p>
+                          Set the |algorithm| field to an
+                          `AlgorithmIdentifier` ASN.1 type with the following
+                          properties:
+                        </p>
+                        <ul>
+                          <li>
+                            <dl class="switch">
+                              <dt>If the {{Algorithm/name}} member of |keyAlgorithm| is "`MLKEM768-P256`":</dt>
+                              <dd>
+                                <p>
+                                  Set the |algorithm| object identifier to the `id-MLKEM768-ECDH-P256-SHA3-256` (1.3.6.1.5.5.7.6.59) OID.
+                                </p>
+                              </dd>
+                              <dt>If the {{Algorithm/name}} member of |keyAlgorithm| is "`MLKEM768-X25519`":</dt>
+                              <dd>
+                                <p>
+                                  Set the |algorithm| object identifier to the `id-MLKEM768-X25519-SHA3-256` (1.3.6.1.5.5.7.6.58) OID.
+                                </p>
+                              </dd>
+                              <dt>If the {{Algorithm/name}} member of |keyAlgorithm| is "`MLKEM1024-P384`":</dt>
+                              <dd>
+                                <p>
+                                  Set the |algorithm| object identifier to the `id-MLKEM1024-ECDH-P384-SHA3-256` (1.3.6.1.5.5.7.6.63) OID.
+                                </p>
+                              </dd>
+                              <dt>Otherwise:</dt>
+                              <dd>
+                                <p>
+                                  [= exception/throw =] a {{NotSupportedError}}.
+                                </p>
+                              </dd>
+                            </dl>
+                          </li>
+                        </ul>
+                      </li>
+                      <li>
+                        <p>
+                          Set the |subjectPublicKey| field to |keyData|.
+                        </p>
+                      </li>
+                    </ul>
+                  </li>
+                  <li>
+                    <p>
+                      Let |result| be the result of DER-encoding |data|.
+                    </p>
+                  </li>
+                </ol>
+              </dd>
               <dt>If |format| is {{KeyFormat/"raw-public"}}:</dt>
               <dd>
                 <ol>
@@ -8904,6 +9110,36 @@ alg: "K256" }
           </td>
           <td>
             [[CSOR]], [[RFC9935]]
+          </td>
+        </tr>
+        <tr>
+          <td>id-MLKEM768-X25519-SHA3-256 (1.3.6.1.5.5.7.6.58)</td>
+          <td>BIT STRING</td>
+          <td>
+            "`MLKEM768-X25519`"
+          </td>
+          <td>
+            [[draft-ietf-lamps-pq-composite-kem]]
+          </td>
+        </tr>
+        <tr>
+          <td>id-MLKEM768-ECDH-P256-SHA3-256 (1.3.6.1.5.5.7.6.59)</td>
+          <td>BIT STRING</td>
+          <td>
+            "`MLKEM768-P256`"
+          </td>
+          <td>
+            [[draft-ietf-lamps-pq-composite-kem]]
+          </td>
+        </tr>
+        <tr>
+          <td>id-MLKEM1024-ECDH-P384-SHA3-256 (1.3.6.1.5.5.7.6.63)</td>
+          <td>BIT STRING</td>
+          <td>
+            "`MLKEM1024-P384`"
+          </td>
+          <td>
+            [[draft-ietf-lamps-pq-composite-kem]]
           </td>
         </tr>
         <tr>

--- a/index.html
+++ b/index.html
@@ -7646,11 +7646,6 @@ dictionary Argon2Params : Algorithm {
       </section>
       <section id="hybrid-kems-operations-import-key">
         <h5>Import Key</h5>
-        <div class=note>
-          <p>
-            TODO: {{KeyFormat/"spki"}} and {{KeyFormat/"pkcs8"}}.
-          </p>
-        </div>
         <ol>
           <li>
             <p>Let |keyData| be the key data to be imported.</p>

--- a/index.html
+++ b/index.html
@@ -94,11 +94,6 @@
         "href": "https://csrc.nist.gov/projects/computer-security-objects-register/algorithm-registration",
         "publisher": "NIST"
       },
-      "draft-ietf-lamps-pq-composite-kem": {
-        "title": "Composite ML-KEM for use in X.509 Public Key Infrastructure",
-        "href": "https://datatracker.ietf.org/doc/draft-ietf-lamps-pq-composite-kem/",
-        "publisher": "IETF"
-      },
       "draft-ietf-hpke-pq": {
         "title": "Post-Quantum Hybrid Key Encapsulation Mechanisms for HPKE",
         "href": "https://datatracker.ietf.org/doc/draft-ietf-hpke-pq/",
@@ -7789,7 +7784,7 @@ dictionary Argon2Params : Algorithm {
         <h5>Import Key</h5>
         <div class=note>
           <p>
-            TODO: {{KeyFormat/"pkcs8"}}.
+            TODO: {{KeyFormat/"spki"}} and {{KeyFormat/"pkcs8"}}.
           </p>
         </div>
         <ol>
@@ -7798,123 +7793,6 @@ dictionary Argon2Params : Algorithm {
           </li>
           <li>
             <dl class="switch">
-              <dt>If |format| is {{KeyFormat/"spki"}}:</dt>
-              <dd>
-                <ol>
-                  <li>
-                    <p>
-                      If |usages| contains an entry which is not
-                      "`encapsulateKey`" or "`encapsulateBits`"
-                      then [= exception/throw =] a
-                      {{SyntaxError}}.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Let |spki| be the result of running the
-                      <a data-cite="webcrypto#concept-parse-a-spki">parse a subjectPublicKeyInfo</a>
-                      algorithm over |keyData|.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      If an error occurred while parsing,
-                      then [= exception/throw =] a
-                      {{DataError}}.
-                    </p>
-                  </li>
-                  <li>
-                    <dl class="switch">
-                      <dt>If the {{Algorithm/name}} member of |normalizedAlgorithm| is "`MLKEM768-P256`":</dt>
-                      <dd>
-                        <p>
-                          Let |expectedOid| be `id-MLKEM768-ECDH-P256-SHA3-256` (1.3.6.1.5.5.7.6.59).
-                        </p>
-                      </dd>
-                      <dt>If the {{Algorithm/name}} member of |normalizedAlgorithm| is "`MLKEM768-X25519`":</dt>
-                      <dd>
-                        <p>
-                          Let |expectedOid| be `id-MLKEM768-X25519-SHA3-256` (1.3.6.1.5.5.7.6.58).
-                        </p>
-                      </dd>
-                      <dt>If the {{Algorithm/name}} member of |normalizedAlgorithm| is "`MLKEM1024-P384`":</dt>
-                      <dd>
-                        <p>
-                          Let |expectedOid| be `id-MLKEM1024-ECDH-P384-SHA3-256` (1.3.6.1.5.5.7.6.63).
-                        </p>
-                      </dd>
-                      <dt>Otherwise:</dt>
-                      <dd>
-                        <p>
-                          [= exception/throw =] a {{NotSupportedError}}.
-                        </p>
-                      </dd>
-                    </dl>
-                  </li>
-                  <li>
-                    <p>
-                      If the `algorithm` object identifier field of the
-                      `algorithm` AlgorithmIdentifier field of |spki| is
-                      not equal to |expectedOid|,
-                      then [= exception/throw =] a {{DataError}}.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      If the `parameters` field of the `algorithm`
-                      AlgorithmIdentifier field of |spki| is present,
-                      then [= exception/throw =] a
-                      {{DataError}}.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Let |publicKey| be the hybrid KEM public key identified by
-                      the `subjectPublicKey` field of |spki|.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      If the length in bytes of |publicKey| is not the raw public key
-                      length, `Nek`, for the hybrid KEM instance
-                      indicated by the {{Algorithm/name}} member of
-                      |normalizedAlgorithm| in Section 4 of
-                      [[draft-irtf-cfrg-concrete-hybrid-kems-03]], then
-                      [= exception/throw =] a {{DataError}}.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Let |key| be a new {{CryptoKey}}
-                      that represents |publicKey|.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot
-                      of |key| to {{KeyType/"public"}}
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Let |algorithm| be a new {{KeyAlgorithm}}.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Set the {{KeyAlgorithm/name}} attribute of
-                      |algorithm| to the {{Algorithm/name}} attribute of
-                      |normalizedAlgorithm|.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-algorithm">`[[algorithm]]`</a>
-                      internal slot of |key| to |algorithm|.
-                    </p>
-                  </li>
-                </ol>
-              </dd>
               <dt>If |format| is {{KeyFormat/"raw-public"}}:</dt>
               <dd>
                 <ol>
@@ -8232,11 +8110,6 @@ dictionary Argon2Params : Algorithm {
       </section>
       <section id="hybrid-kems-operations-export-key">
         <h5>Export Key</h5>
-        <div class=note>
-          <p>
-            TODO: {{KeyFormat/"pkcs8"}}.
-          </p>
-        </div>
         <ol>
           <li>
             <p>
@@ -8252,85 +8125,6 @@ dictionary Argon2Params : Algorithm {
           </li>
           <li>
             <dl class="switch">
-              <dt>If |format| is {{KeyFormat/"spki"}}:</dt>
-              <dd>
-                <ol>
-                  <li>
-                    <p>
-                      If the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot
-                      of |key| is not {{KeyType/"public"}}, then [= exception/throw =] an {{InvalidAccessError}}.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Let |keyAlgorithm| be the <a data-cite="webcrypto#dfn-CryptoKey-slot-algorithm">`[[algorithm]]`</a> internal slot of |key|.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Let |keyData| be a [= byte sequence =] containing
-                      the raw octets of the key represented by the <a data-cite="webcrypto#dfn-CryptoKey-slot-handle">`[[handle]]`</a> internal slot of
-                      |key|.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Let |data| be an instance of the `SubjectPublicKeyInfo`
-                      ASN.1 structure defined in [[RFC5280]]
-                      with the following properties:
-                    </p>
-                    <ul>
-                      <li>
-                        <p>
-                          Set the |algorithm| field to an
-                          `AlgorithmIdentifier` ASN.1 type with the following
-                          properties:
-                        </p>
-                        <ul>
-                          <li>
-                            <dl class="switch">
-                              <dt>If the {{Algorithm/name}} member of |keyAlgorithm| is "`MLKEM768-P256`":</dt>
-                              <dd>
-                                <p>
-                                  Set the |algorithm| object identifier to the `id-MLKEM768-ECDH-P256-SHA3-256` (1.3.6.1.5.5.7.6.59) OID.
-                                </p>
-                              </dd>
-                              <dt>If the {{Algorithm/name}} member of |keyAlgorithm| is "`MLKEM768-X25519`":</dt>
-                              <dd>
-                                <p>
-                                  Set the |algorithm| object identifier to the `id-MLKEM768-X25519-SHA3-256` (1.3.6.1.5.5.7.6.58) OID.
-                                </p>
-                              </dd>
-                              <dt>If the {{Algorithm/name}} member of |keyAlgorithm| is "`MLKEM1024-P384`":</dt>
-                              <dd>
-                                <p>
-                                  Set the |algorithm| object identifier to the `id-MLKEM1024-ECDH-P384-SHA3-256` (1.3.6.1.5.5.7.6.63) OID.
-                                </p>
-                              </dd>
-                              <dt>Otherwise:</dt>
-                              <dd>
-                                <p>
-                                  [= exception/throw =] a {{NotSupportedError}}.
-                                </p>
-                              </dd>
-                            </dl>
-                          </li>
-                        </ul>
-                      </li>
-                      <li>
-                        <p>
-                          Set the |subjectPublicKey| field to |keyData|.
-                        </p>
-                      </li>
-                    </ul>
-                  </li>
-                  <li>
-                    <p>
-                      Let |result| be the result of DER-encoding |data|.
-                    </p>
-                  </li>
-                </ol>
-              </dd>
               <dt>If |format| is {{KeyFormat/"raw-public"}}:</dt>
               <dd>
                 <ol>
@@ -9246,36 +9040,6 @@ alg: "K256" }
           </td>
           <td>
             [[CSOR]], [[RFC9935]]
-          </td>
-        </tr>
-        <tr>
-          <td>id-MLKEM768-X25519-SHA3-256 (1.3.6.1.5.5.7.6.58)</td>
-          <td>BIT STRING</td>
-          <td>
-            "`MLKEM768-X25519`"
-          </td>
-          <td>
-            [[draft-ietf-lamps-pq-composite-kem]]
-          </td>
-        </tr>
-        <tr>
-          <td>id-MLKEM768-ECDH-P256-SHA3-256 (1.3.6.1.5.5.7.6.59)</td>
-          <td>BIT STRING</td>
-          <td>
-            "`MLKEM768-P256`"
-          </td>
-          <td>
-            [[draft-ietf-lamps-pq-composite-kem]]
-          </td>
-        </tr>
-        <tr>
-          <td>id-MLKEM1024-ECDH-P384-SHA3-256 (1.3.6.1.5.5.7.6.63)</td>
-          <td>BIT STRING</td>
-          <td>
-            "`MLKEM1024-P384`"
-          </td>
-          <td>
-            [[draft-ietf-lamps-pq-composite-kem]]
           </td>
         </tr>
         <tr>

--- a/index.html
+++ b/index.html
@@ -7782,11 +7782,6 @@ dictionary Argon2Params : Algorithm {
       </section>
       <section id="hybrid-kems-operations-import-key">
         <h5>Import Key</h5>
-        <div class=note>
-          <p>
-            TODO: {{KeyFormat/"spki"}} and {{KeyFormat/"pkcs8"}}.
-          </p>
-        </div>
         <ol>
           <li>
             <p>Let |keyData| be the key data to be imported.</p>

--- a/index.html
+++ b/index.html
@@ -7787,21 +7787,9 @@ dictionary Argon2Params : Algorithm {
       </section>
       <section id="hybrid-kems-operations-import-key">
         <h5>Import Key</h5>
-        <div class=issue>
+        <div class=note>
           <p>
-            {{KeyFormat/"pkcs8"}} import is so far unspecified.
-            [[draft-ietf-lamps-pq-composite-kem]] defines
-            `OneAsymmetricKey.privateKey` as an `OCTET STRING` containing
-            `mlkemSeed || tradSK`, where `mlkemSeed` is the 64-byte ML-KEM
-            `d || z` seed and |tradSK| is the traditional private key encoding.
-          </p>
-          <p>
-            Importing this representation would produce a usable decapsulation
-            key, but we cannot recover the 32-byte seed used by
-            {{KeyFormat/"raw-seed"}} and {{KeyFormat/"jwk"}}.
-            We could require |extractable| to be `false` which would remove those
-            cases, or otherwise define that seed-based export formats fail for keys
-            that are not backed by a 32-byte seed.
+            TODO: {{KeyFormat/"pkcs8"}}.
           </p>
         </div>
         <ol>
@@ -8244,24 +8232,9 @@ dictionary Argon2Params : Algorithm {
       </section>
       <section id="hybrid-kems-operations-export-key">
         <h5>Export Key</h5>
-        <div class=issue>
+        <div class=note>
           <p>
-            {{KeyFormat/"pkcs8"}} export is so far unspecified.
-            [[draft-ietf-lamps-pq-composite-kem]] defines
-            `OneAsymmetricKey.privateKey` as an `OCTET STRING` containing
-            `mlkemSeed || tradSK`, where `mlkemSeed` is the 64-byte ML-KEM
-            `d || z` seed and |tradSK| is the traditional private key encoding.
-          </p>
-          <p>
-            Exporting this format can work for generated keys, or keys imported
-            with the 32-byte seed used by {{KeyFormat/"raw-seed"}} and
-            {{KeyFormat/"jwk"}}, provided the implementation can derive and
-            serialize the component private keys. For keys imported from
-            {{KeyFormat/"pkcs8"}}, we only have the LAMPS component
-            private-key representation. That representation is sufficient for
-            decapsulation and for {{KeyFormat/"pkcs8"}} re-export, but we cannot
-            export it as {{KeyFormat/"raw-seed"}} or {{KeyFormat/"jwk"}} unless
-            the key is backed by a 32-byte seed.
+            TODO: {{KeyFormat/"pkcs8"}}.
           </p>
         </div>
         <ol>

--- a/index.html
+++ b/index.html
@@ -104,6 +104,18 @@
         "href": "https://datatracker.ietf.org/doc/draft-ietf-hpke-hpke/",
         "publisher": "IETF"
       },
+      "draft-irtf-cfrg-hybrid-kems-09": {
+        "title": "Hybrid PQ/T Key Encapsulation Mechanisms",
+        "href": "https://www.ietf.org/archive/id/draft-irtf-cfrg-hybrid-kems-09.html",
+        "publisher": "IETF",
+        "date": "March 2026"
+      },
+      "draft-irtf-cfrg-concrete-hybrid-kems-03": {
+        "title": "Concrete Hybrid PQ/T Key Encapsulation Mechanisms",
+        "href": "https://www.ietf.org/archive/id/draft-irtf-cfrg-concrete-hybrid-kems-03.html",
+        "publisher": "IETF",
+        "date": "March 2026"
+      },
     },
   };
   </script>
@@ -114,8 +126,9 @@
     <p>
       This specification defines a number of post-quantum secure and
       modern cryptographic algorithms for the [[webcrypto | Web Cryptography API]],
-      namely ML-KEM, ML-DSA, SLH-DSA, AES-OCB, ChaCha20-Poly1305,
-      SHA-3, cSHAKE, TurboSHAKE, KangarooTwelve, KMAC, and Argon2.
+      namely ML-KEM, Hybrid KEMs, ML-DSA, SLH-DSA, AES-OCB,
+      ChaCha20-Poly1305, SHA-3, cSHAKE, TurboSHAKE, KangarooTwelve,
+      KMAC, and Argon2.
     </p>
   </section>
   <section id="sotd">
@@ -134,6 +147,7 @@
     </p>
     <ul>
       <li><a href="#ml-kem">ML-KEM</a> [[FIPS-203]]</li>
+      <li><a href="#hybrid-kems">Hybrid KEMs</a> [[draft-irtf-cfrg-concrete-hybrid-kems-03]]</li>
       <li><a href="#ml-dsa">ML-DSA</a> [[FIPS-204]]</li>
       <li><a href="#slh-dsa">SLH-DSA</a> [[FIPS-205]]</li>
       <li><a href="#aes-ocb">AES-OCB</a> [[RFC7253]]</li>
@@ -144,7 +158,7 @@
       <li><a href="#argon2">Argon2d, Argon2i, and Argon2id</a> [[RFC9106]]</li>
     </ul>
     <p>
-      To accommodate the usage of ML-KEM, and possibly future other KEMs,
+      To accommodate the usage of ML-KEM, Hybrid KEMs, and possibly future other KEMs,
       this proposal introduces functions for key encapsulation and decapsulation;
       <a href="#dfn-SubtleCrypto-method-encapsulateKey">`SubtleCrypto.encapsulateKey`</a>,
       <a href="#dfn-SubtleCrypto-method-encapsulateBits">`SubtleCrypto.encapsulateBits`</a>,
@@ -7487,6 +7501,740 @@ dictionary Argon2Params : Algorithm {
     </section>
   </section>
 
+  <section id="hybrid-kems">
+    <h3>Hybrid KEMs</h3>
+    <section id="hybrid-kems-description" class="informative">
+      <h4>Description</h4>
+      <p>
+        This describes using hybrid post-quantum/traditional key
+        encapsulation mechanisms for key encapsulation and decapsulation,
+        as specified by [[draft-irtf-cfrg-concrete-hybrid-kems-03]].
+      </p>
+    </section>
+    <section id="hybrid-kems-registration">
+      <h4>Registration</h4>
+      <p>
+        The <a data-cite="webcrypto#recognized-algorithm-name">recognized algorithm names</a> for
+        this algorithm are "`MLKEM768-P256`", "`MLKEM768-X25519`" and
+        "`MLKEM1024-P384`".
+      </p>
+      <table>
+        <thead>
+          <tr>
+            <th><a data-cite="webcrypto#supported-operations">Operation</a></th>
+            <th><a data-cite="webcrypto#algorithm-specific-params">Parameters</a></th>
+            <th><a data-cite="webcrypto#algorithm-result">Result</a></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>encapsulate</td>
+            <td>None</td>
+            <td>{{EncapsulatedBits}}</td>
+          </tr>
+          <tr>
+            <td>decapsulate</td>
+            <td>None</td>
+            <td>[= byte sequence =]</td>
+          </tr>
+          <tr>
+            <td>generateKey</td>
+            <td>None</td>
+            <td>{{CryptoKeyPair}}</td>
+          </tr>
+          <tr>
+            <td>importKey</td>
+            <td>None</td>
+            <td>{{CryptoKey}}</td>
+          </tr>
+          <tr>
+            <td>exportKey</td>
+            <td>None</td>
+            <td>object</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+    <section id="hybrid-kems-operations">
+      <h4>Operations</h4>
+      <section id="hybrid-kems-operations-encapsulate">
+        <h5>Encapsulate</h5>
+        <ol>
+          <li>
+            <p>
+              If the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot of
+              |key| is not {{KeyType/"public"}}, then [= exception/throw =] an {{InvalidAccessError}}.
+            </p>
+          </li>
+          <li>
+            <p>
+              Let |sharedKey| and |ciphertext| be the outputs that result
+              from performing the Encaps function for the hybrid
+              KEM instance indicated by the {{Algorithm/name}} member of
+              |algorithm| in Section 4 of
+              [[draft-irtf-cfrg-concrete-hybrid-kems-03]], using the key
+              represented by the <a data-cite="webcrypto#dfn-CryptoKey-slot-handle">`[[handle]]`</a>
+              internal slot of |key| as the |ek| input parameter.
+            </p>
+          </li>
+          <li>
+            <p>
+              If the Encaps function returned an error, return an {{OperationError}}.
+            </p>
+          </li>
+          <li>
+            <p>
+              Let |result| be a new {{EncapsulatedBits}}
+              dictionary.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the {{EncapsulatedBits/sharedKey}} attribute
+              of |result| to the result of [= ArrayBuffer/create | creating =]
+              an {{ArrayBuffer}} containing |sharedKey|.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the {{EncapsulatedBits/ciphertext}} attribute
+              of |result| to the result of [= ArrayBuffer/create | creating =]
+              an {{ArrayBuffer}} containing |ciphertext|.
+            </p>
+          </li>
+          <li>
+            <p>
+              Return |result|.
+            </p>
+          </li>
+        </ol>
+      </section>
+      <section id="hybrid-kems-operations-decapsulate">
+        <h5>Decapsulate</h5>
+        <ol>
+          <li>
+            <p>
+              If the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot of
+              |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
+            </p>
+          </li>
+          <li>
+            <p>
+              Let |sharedKey| be the output that results from performing
+              the Decaps function for the hybrid KEM instance
+              indicated by the {{Algorithm/name}} member of |algorithm| in
+              Section 4 of [[draft-irtf-cfrg-concrete-hybrid-kems-03]],
+              using the key represented by the <a data-cite="webcrypto#dfn-CryptoKey-slot-handle">`[[handle]]`</a>
+              internal slot of |key| as the |dk| input parameter, and
+              |ciphertext| as the |ct| input parameter.
+            </p>
+          </li>
+          <li>
+            <p>
+              If the Decaps function returned an error, return an {{OperationError}}.
+            </p>
+          </li>
+          <li>
+            <p>
+              Return |sharedKey|.
+            </p>
+          </li>
+        </ol>
+      </section>
+      <section id="hybrid-kems-operations-generate-key">
+        <h5>Generate Key</h5>
+        <ol>
+          <li>
+            <p>
+              If |usages| contains an entry which is not
+              one of "`encapsulateKey`", "`encapsulateBits`",
+              "`decapsulateKey`" or "`decapsulateBits`",
+              then [= exception/throw =] a
+              {{SyntaxError}}.
+            </p>
+          </li>
+          <li>
+            <p>
+              Generate a hybrid KEM key pair by performing the
+              GenerateKeyPair function described in Section 5.2 of
+              [[draft-irtf-cfrg-hybrid-kems-09]] with the hybrid
+              KEM instance indicated by the {{Algorithm/name}} member of
+              |normalizedAlgorithm|.
+            </p>
+          </li>
+          <li>
+            <p>
+              If the key generation step fails,
+              then [= exception/throw =] an
+              {{OperationError}}.
+            </p>
+          </li>
+          <li>
+            <p>
+              Let |algorithm| be a new {{KeyAlgorithm}} object.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the {{KeyAlgorithm/name}} attribute of
+              |algorithm| to the {{Algorithm/name}} attribute of
+              |normalizedAlgorithm|.
+            </p>
+          </li>
+          <li>
+            <p>
+              Let |publicKey| be a new {{CryptoKey}}
+              representing the encapsulation key of the generated key pair.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot of
+              |publicKey| to {{KeyType/"public"}}.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-algorithm">`[[algorithm]]`</a> internal
+              slot of |publicKey| to |algorithm|.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-extractable">`[[extractable]]`</a> internal
+              slot of |publicKey| to true.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-usages">`[[usages]]`</a> internal slot of
+              |publicKey| to be the
+              <a data-cite="webcrypto#concept-usage-intersection">usage intersection</a> of
+              |usages| and `[ "encapsulateKey", "encapsulateBits" ]`.
+            </p>
+          </li>
+          <li>
+            <p>
+              Let |privateKey| be a new {{CryptoKey}}
+              representing the decapsulation key of the generated key pair.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot of
+              |privateKey| to {{KeyType/"private"}}.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-algorithm">`[[algorithm]]`</a> internal
+              slot of |privateKey| to |algorithm|.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-extractable">`[[extractable]]`</a> internal
+              slot of |privateKey| to |extractable|.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-usages">`[[usages]]`</a> internal slot of
+              |privateKey| to be the
+              <a data-cite="webcrypto#concept-usage-intersection">usage intersection</a> of
+              |usages| and `[ "decapsulateKey", "decapsulateBits" ]`.
+            </p>
+          </li>
+          <li>
+            <p>
+              Let |result| be a new {{CryptoKeyPair}}
+              dictionary.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the {{CryptoKeyPair/publicKey}} attribute
+              of |result| to be |publicKey|.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the {{CryptoKeyPair/privateKey}} attribute
+              of |result| to be |privateKey|.
+            </p>
+          </li>
+          <li>
+            <p>
+              Return |result|.
+            </p>
+          </li>
+        </ol>
+      </section>
+      <section id="hybrid-kems-operations-import-key">
+        <h5>Import Key</h5>
+        <div class=note>
+          <p>
+            TODO: {{KeyFormat/"spki"}} and {{KeyFormat/"pkcs8"}}.
+          </p>
+        </div>
+        <ol>
+          <li>
+            <p>Let |keyData| be the key data to be imported.</p>
+          </li>
+          <li>
+            <dl class="switch">
+              <dt>If |format| is {{KeyFormat/"raw-public"}}:</dt>
+              <dd>
+                <ol>
+                  <li>
+                    <p>
+                      If |usages| contains an entry which is not
+                      "`encapsulateKey`" or "`encapsulateBits`"
+                      then [= exception/throw =] a
+                      {{SyntaxError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |data| be |keyData|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the length in bytes of |data| is not the raw public key
+                      length, `Nek`, for the hybrid KEM instance
+                      indicated by the {{Algorithm/name}} member of
+                      |normalizedAlgorithm| in Section 4 of
+                      [[draft-irtf-cfrg-concrete-hybrid-kems-03]], then
+                      [= exception/throw =] a {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |key| be a new {{CryptoKey}}
+                      that represents the hybrid KEM public key data in |data|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot
+                      of |key| to {{KeyType/"public"}}
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |algorithm| be a new {{KeyAlgorithm}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the {{KeyAlgorithm/name}} attribute of
+                      |algorithm| to the {{Algorithm/name}} attribute of
+                      |normalizedAlgorithm|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-algorithm">`[[algorithm]]`</a>
+                      internal slot of |key| to |algorithm|.
+                    </p>
+                  </li>
+                </ol>
+              </dd>
+              <dt>If |format| is {{KeyFormat/"raw-seed"}}:</dt>
+              <dd>
+                <ol>
+                  <li>
+                    <p>
+                      If |usages| contains an entry which is not
+                      "`decapsulateKey`" or "`decapsulateBits`"
+                      then [= exception/throw =] a
+                      {{SyntaxError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |data| be |keyData|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the length in bits of |data| is not 256
+                      then [= exception/throw =] a
+                      {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |keyPair| be the result of performing the
+                      DeriveKeyPair function described in Section 5.5 of
+                      [[draft-irtf-cfrg-hybrid-kems-09]] with the
+                      hybrid KEM instance indicated by the {{Algorithm/name}}
+                      member of |normalizedAlgorithm|, using |data| as the
+                      |seed| input parameter.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the DeriveKeyPair function returned an error,
+                      then [= exception/throw =] an {{OperationError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |key| be a new {{CryptoKey}}
+                      that represents the hybrid KEM private key identified by
+                      the decapsulation key of |keyPair|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot
+                      of |key| to {{KeyType/"private"}}
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |algorithm| be a new {{KeyAlgorithm}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the {{KeyAlgorithm/name}} attribute of
+                      |algorithm| to the {{Algorithm/name}} attribute of
+                      |normalizedAlgorithm|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-algorithm">`[[algorithm]]`</a>
+                      internal slot of |key| to |algorithm|.
+                    </p>
+                  </li>
+                </ol>
+              </dd>
+              <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
+              <dd>
+                <ol>
+                  <li>
+                    <dl class="switch">
+                      <dt>If |keyData| is a {{JsonWebKey}} dictionary:</dt>
+                      <dd><p>Let |jwk| equal |keyData|.</p></dd>
+                      <dt>Otherwise:</dt>
+                      <dd><p>[= exception/Throw =] a {{DataError}}.</p></dd>
+                    </dl>
+                  </li>
+                  <li>
+                    <p>
+                      If the {{JsonWebKey/priv}} field of |jwk| is present
+                      and if |usages| contains an entry which is not
+                      "`decapsulateKey`" or "`decapsulateBits`"
+                      then [= exception/throw =] a
+                      {{SyntaxError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the {{JsonWebKey/priv}} field of |jwk| is not present
+                      and if |usages| contains an entry which is not
+                      "`encapsulateKey`" or "`encapsulateBits`"
+                      then [= exception/throw =] a
+                      {{SyntaxError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the {{JsonWebKey/kty}} field of |jwk| is not
+                      "`AKP`",
+                      then [= exception/throw =] a
+                      {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the {{JsonWebKey/alg}} field of |jwk| is not
+                      equal to the {{Algorithm/name}} member of
+                      |normalizedAlgorithm|, then [= exception/throw =] a
+                      {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If |usages| is non-empty and the {{JsonWebKey/use}} field of |jwk| is present
+                      and is not equal to "`enc`", then [= exception/throw =] a
+                      {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the {{JsonWebKey/key_ops}} field of |jwk| is present, and
+                      is invalid according to the requirements of JSON Web
+                      Key [[JWK]], or it does not contain all of the specified |usages|
+                      values,
+                      then [= exception/throw =] a
+                      {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the {{JsonWebKey/ext}} field of |jwk| is present and
+                      has the value false and |extractable| is true,
+                      then [= exception/throw =] a
+                      {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <dl class="switch">
+                      <dt>If the {{JsonWebKey/priv}} field of |jwk| is present:</dt>
+                      <dd>
+                        <ol>
+                          <li>
+                            <p>
+                              If the {{JsonWebKey/priv}} attribute of |jwk|
+                              does not contain a valid base64url encoded
+                              32-byte seed representing a hybrid KEM private key,
+                              then [= exception/throw =] a {{DataError}}.
+                            </p>
+                          </li>
+                          <li>
+                            <p>
+                              Let |key| be a new {{CryptoKey}} object that represents the
+                              hybrid KEM private key identified by interpreting the
+                              {{JsonWebKey/priv}} attribute of |jwk|
+                              as a base64url encoded seed.
+                            </p>
+                          </li>
+                          <li>
+                            <p>
+                              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a>
+                              internal slot of |key| to {{KeyType/"private"}}.
+                            </p>
+                          </li>
+                          <li>
+                            <p>
+                              If the {{JsonWebKey/pub}} attribute of |jwk|
+                              does not contain the base64url encoded public key
+                              representing the hybrid KEM public key
+                              corresponding to |key|,
+                              then [= exception/throw =] a {{DataError}}.
+                            </p>
+                          </li>
+                        </ol>
+                      </dd>
+                      <dt>Otherwise:</dt>
+                      <dd>
+                        <ol>
+                          <li>
+                            <p>
+                              If the {{JsonWebKey/pub}} attribute of |jwk|
+                              does not contain a valid base64url encoded raw
+                              public key whose length is `Nek` for the
+                              hybrid KEM instance indicated by the
+                              {{Algorithm/name}} member of
+                              |normalizedAlgorithm| in Section 4 of
+                              [[draft-irtf-cfrg-concrete-hybrid-kems-03]],
+                              then [= exception/throw =] a {{DataError}}.
+                            </p>
+                          </li>
+                          <li>
+                            <p>
+                              Let |key| be a new {{CryptoKey}} object that represents the
+                              hybrid KEM public key identified by interpreting the
+                              {{JsonWebKey/pub}} attribute of |jwk|
+                              as a base64url encoded public key.
+                            </p>
+                          </li>
+                          <li>
+                            <p>
+                              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a>
+                              internal slot of |key| to {{KeyType/"public"}}.
+                            </p>
+                          </li>
+                        </ol>
+                      </dd>
+                    </dl>
+                  </li>
+                  <li>
+                    <p>
+                      Let |algorithm| be a new instance of a {{KeyAlgorithm}} object.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the {{KeyAlgorithm/name}} attribute of
+                      |algorithm| to the {{Algorithm/name}} member of |normalizedAlgorithm|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-algorithm">`[[algorithm]]`</a>
+                      internal slot of |key| to |algorithm|.
+                    </p>
+                  </li>
+                </ol>
+              </dd>
+              <dt>Otherwise:</dt>
+              <dd>
+                [= exception/throw =] a
+                {{NotSupportedError}}.
+              </dd>
+            </dl>
+          </li>
+          <li>
+            <p>
+              Return |key|.
+            </p>
+          </li>
+        </ol>
+      </section>
+      <section id="hybrid-kems-operations-export-key">
+        <h5>Export Key</h5>
+        <ol>
+          <li>
+            <p>
+              Let |key| be the {{CryptoKey}} to be
+              exported.
+            </p>
+          </li>
+          <li>
+            <p>
+              If the underlying cryptographic key material represented by the <a data-cite="webcrypto#dfn-CryptoKey-slot-handle">`[[handle]]`</a> internal slot of |key|
+              cannot be accessed, then [= exception/throw =] an {{OperationError}}.
+            </p>
+          </li>
+          <li>
+            <dl class="switch">
+              <dt>If |format| is {{KeyFormat/"raw-public"}}:</dt>
+              <dd>
+                <ol>
+                  <li>
+                    <p>
+                      If the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot
+                      of |key| is not {{KeyType/"public"}}, then [= exception/throw =] an {{InvalidAccessError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |data| be a [= byte sequence =] containing
+                      the raw octets of the key represented by the <a data-cite="webcrypto#dfn-CryptoKey-slot-handle">`[[handle]]`</a> internal slot of
+                      |key|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |result| be |data|.
+                    </p>
+                  </li>
+                </ol>
+              </dd>
+              <dt>If |format| is {{KeyFormat/"raw-seed"}}:</dt>
+              <dd>
+                <ol>
+                  <li>
+                    <p>
+                      If the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot
+                      of |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |data| be a [= byte sequence =] containing the 32-byte seed represented by
+                      the <a data-cite="webcrypto#dfn-CryptoKey-slot-handle">`[[handle]]`</a>
+                      internal slot of |key|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |result| be |data|.
+                    </p>
+                  </li>
+                </ol>
+              </dd>
+              <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
+              <dd>
+                <ol>
+                  <li>
+                    <p>
+                      Let |jwk| be a new {{JsonWebKey}}
+                      dictionary.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |keyAlgorithm| be the <a data-cite="webcrypto#dfn-CryptoKey-slot-algorithm">`[[algorithm]]`</a> internal slot of |key|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the `kty` attribute of |jwk| to
+                      "`AKP`".
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the `alg` attribute of |jwk| to the
+                      {{Algorithm/name}} member of |keyAlgorithm|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the {{JsonWebKey/pub}} attribute of |jwk|
+                      to the base64url encoded public key corresponding
+                      to the <a data-cite="webcrypto#dfn-CryptoKey-slot-handle">`[[handle]]`</a>
+                      internal slot of |key|.
+                    </p>
+                  </li>
+                  <li>
+                    <dl class="switch">
+                      <dt>
+                        If the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot
+                        of |key| is {{KeyType/"private"}}:
+                      </dt>
+                      <dd>
+                        Set the {{JsonWebKey/priv}} attribute of |jwk|
+                        to the base64url encoded 32-byte seed represented by
+                        the <a data-cite="webcrypto#dfn-CryptoKey-slot-handle">`[[handle]]`</a>
+                        internal slot of |key|.
+                      </dd>
+                    </dl>
+                  </li>
+                  <li>
+                    <p>
+                      Set the `key_ops` attribute of |jwk| to the {{CryptoKey/usages}} attribute of |key|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the `ext` attribute of |jwk| to the <a data-cite="webcrypto#dfn-CryptoKey-slot-extractable">`[[extractable]]`</a> internal slot
+                      of |key|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |result| be |jwk|.
+                    </p>
+                  </li>
+                </ol>
+              </dd>
+              <dt>Otherwise:</dt>
+              <dd>
+                <p>
+                  [= exception/throw =] a
+                  {{NotSupportedError}}.
+                </p>
+              </dd>
+            </dl>
+          </li>
+          <li>
+            <p>
+              Return |result|.
+            </p>
+          </li>
+        </ol>
+      </section>
+    </section>
+  </section>
+
   <section id="iana-section">
     <h2>IANA Considerations</h2>
     <section id="iana-section-jws-jwa">
@@ -7641,6 +8389,30 @@ dictionary Argon2Params : Algorithm {
         <li>Change Controller: W3C Web Application Security Working Group</li>
         <li>Specification Document(s): [[ This Document ]]</li>
       </ul>
+      <ul>
+        <li>Algorithm Name: "MLKEM768-P256"</li>
+        <li>Algorithm Description: Hybrid KEM using ML-KEM-768 and P-256</li>
+        <li>Algorithm Usage Location(s): "JWK"</li>
+        <li>JOSE Implementation Requirements: Optional</li>
+        <li>Change Controller: W3C Web Application Security Working Group</li>
+        <li>Specification Document(s): [[ This Document ]]</li>
+      </ul>
+      <ul>
+        <li>Algorithm Name: "MLKEM768-X25519"</li>
+        <li>Algorithm Description: Hybrid KEM using ML-KEM-768 and X25519</li>
+        <li>Algorithm Usage Location(s): "JWK"</li>
+        <li>JOSE Implementation Requirements: Optional</li>
+        <li>Change Controller: W3C Web Application Security Working Group</li>
+        <li>Specification Document(s): [[ This Document ]]</li>
+      </ul>
+      <ul>
+        <li>Algorithm Name: "MLKEM1024-P384"</li>
+        <li>Algorithm Description: Hybrid KEM using ML-KEM-1024 and P-384</li>
+        <li>Algorithm Usage Location(s): "JWK"</li>
+        <li>JOSE Implementation Requirements: Optional</li>
+        <li>Change Controller: W3C Web Application Security Working Group</li>
+        <li>Specification Document(s): [[ This Document ]]</li>
+      </ul>
     </section>
     <section id="iana-section-key-operations">
       <h3>JSON Web Key Operations</h3>
@@ -7712,6 +8484,11 @@ dictionary Argon2Params : Algorithm {
         post-quantum/traditional (PQ/T) key establishment as used in
         protocols like [[draft-ietf-hpke-hpke]] and its PQ and PQ/T
         algorithms [[draft-ietf-hpke-pq]].
+      </li>
+      <li>
+        <a href="#hybrid-kems">Hybrid KEMs</a> provide
+        post-quantum/traditional KEM instances that combine ML-KEM with
+        P-256, X25519, or P-384 [[draft-irtf-cfrg-concrete-hybrid-kems-03]].
       </li>
       <li>
         <a href="#ml-dsa">ML-DSA</a> is the primary post-quantum digital
@@ -7896,6 +8673,45 @@ alg: "C20P" }
           <td>
 <pre class=js>
 { name: "ChaCha20-Poly1305" }
+</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>
+<pre class=js>
+{ kty: "AKP",
+alg: "MLKEM768-P256" }
+</pre>
+          </td>
+          <td>
+<pre class=js>
+{ name: "MLKEM768-P256" }
+</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>
+<pre class=js>
+{ kty: "AKP",
+alg: "MLKEM768-X25519" }
+</pre>
+          </td>
+          <td>
+<pre class=js>
+{ name: "MLKEM768-X25519" }
+</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>
+<pre class=js>
+{ kty: "AKP",
+alg: "MLKEM1024-P384" }
+</pre>
+          </td>
+          <td>
+<pre class=js>
+{ name: "MLKEM1024-P384" }
 </pre>
           </td>
         </tr>

--- a/index.html
+++ b/index.html
@@ -94,6 +94,11 @@
         "href": "https://csrc.nist.gov/projects/computer-security-objects-register/algorithm-registration",
         "publisher": "NIST"
       },
+      "draft-ietf-lamps-pq-composite-kem": {
+        "title": "Composite ML-KEM for use in X.509 Public Key Infrastructure",
+        "href": "https://datatracker.ietf.org/doc/draft-ietf-lamps-pq-composite-kem/",
+        "publisher": "IETF"
+      },
       "draft-ietf-hpke-pq": {
         "title": "Post-Quantum Hybrid Key Encapsulation Mechanisms for HPKE",
         "href": "https://datatracker.ietf.org/doc/draft-ietf-hpke-pq/",
@@ -7784,7 +7789,7 @@ dictionary Argon2Params : Algorithm {
         <h5>Import Key</h5>
         <div class=note>
           <p>
-            TODO: {{KeyFormat/"spki"}} and {{KeyFormat/"pkcs8"}}.
+            TODO: {{KeyFormat/"pkcs8"}}.
           </p>
         </div>
         <ol>
@@ -7793,6 +7798,123 @@ dictionary Argon2Params : Algorithm {
           </li>
           <li>
             <dl class="switch">
+              <dt>If |format| is {{KeyFormat/"spki"}}:</dt>
+              <dd>
+                <ol>
+                  <li>
+                    <p>
+                      If |usages| contains an entry which is not
+                      "`encapsulateKey`" or "`encapsulateBits`"
+                      then [= exception/throw =] a
+                      {{SyntaxError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |spki| be the result of running the
+                      <a data-cite="webcrypto#concept-parse-a-spki">parse a subjectPublicKeyInfo</a>
+                      algorithm over |keyData|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If an error occurred while parsing,
+                      then [= exception/throw =] a
+                      {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <dl class="switch">
+                      <dt>If the {{Algorithm/name}} member of |normalizedAlgorithm| is "`MLKEM768-P256`":</dt>
+                      <dd>
+                        <p>
+                          Let |expectedOid| be `id-MLKEM768-ECDH-P256-SHA3-256` (1.3.6.1.5.5.7.6.59).
+                        </p>
+                      </dd>
+                      <dt>If the {{Algorithm/name}} member of |normalizedAlgorithm| is "`MLKEM768-X25519`":</dt>
+                      <dd>
+                        <p>
+                          Let |expectedOid| be `id-MLKEM768-X25519-SHA3-256` (1.3.6.1.5.5.7.6.58).
+                        </p>
+                      </dd>
+                      <dt>If the {{Algorithm/name}} member of |normalizedAlgorithm| is "`MLKEM1024-P384`":</dt>
+                      <dd>
+                        <p>
+                          Let |expectedOid| be `id-MLKEM1024-ECDH-P384-SHA3-256` (1.3.6.1.5.5.7.6.63).
+                        </p>
+                      </dd>
+                      <dt>Otherwise:</dt>
+                      <dd>
+                        <p>
+                          [= exception/throw =] a {{NotSupportedError}}.
+                        </p>
+                      </dd>
+                    </dl>
+                  </li>
+                  <li>
+                    <p>
+                      If the `algorithm` object identifier field of the
+                      `algorithm` AlgorithmIdentifier field of |spki| is
+                      not equal to |expectedOid|,
+                      then [= exception/throw =] a {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the `parameters` field of the `algorithm`
+                      AlgorithmIdentifier field of |spki| is present,
+                      then [= exception/throw =] a
+                      {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |publicKey| be the hybrid KEM public key identified by
+                      the `subjectPublicKey` field of |spki|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the length in bytes of |publicKey| is not the raw public key
+                      length, `Nek`, for the hybrid KEM instance
+                      indicated by the {{Algorithm/name}} member of
+                      |normalizedAlgorithm| in Section 4 of
+                      [[draft-irtf-cfrg-concrete-hybrid-kems-03]], then
+                      [= exception/throw =] a {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |key| be a new {{CryptoKey}}
+                      that represents |publicKey|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot
+                      of |key| to {{KeyType/"public"}}
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |algorithm| be a new {{KeyAlgorithm}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the {{KeyAlgorithm/name}} attribute of
+                      |algorithm| to the {{Algorithm/name}} attribute of
+                      |normalizedAlgorithm|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-algorithm">`[[algorithm]]`</a>
+                      internal slot of |key| to |algorithm|.
+                    </p>
+                  </li>
+                </ol>
+              </dd>
               <dt>If |format| is {{KeyFormat/"raw-public"}}:</dt>
               <dd>
                 <ol>
@@ -8110,6 +8232,11 @@ dictionary Argon2Params : Algorithm {
       </section>
       <section id="hybrid-kems-operations-export-key">
         <h5>Export Key</h5>
+        <div class=note>
+          <p>
+            TODO: {{KeyFormat/"pkcs8"}}.
+          </p>
+        </div>
         <ol>
           <li>
             <p>
@@ -8125,6 +8252,85 @@ dictionary Argon2Params : Algorithm {
           </li>
           <li>
             <dl class="switch">
+              <dt>If |format| is {{KeyFormat/"spki"}}:</dt>
+              <dd>
+                <ol>
+                  <li>
+                    <p>
+                      If the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot
+                      of |key| is not {{KeyType/"public"}}, then [= exception/throw =] an {{InvalidAccessError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |keyAlgorithm| be the <a data-cite="webcrypto#dfn-CryptoKey-slot-algorithm">`[[algorithm]]`</a> internal slot of |key|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |keyData| be a [= byte sequence =] containing
+                      the raw octets of the key represented by the <a data-cite="webcrypto#dfn-CryptoKey-slot-handle">`[[handle]]`</a> internal slot of
+                      |key|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |data| be an instance of the `SubjectPublicKeyInfo`
+                      ASN.1 structure defined in [[RFC5280]]
+                      with the following properties:
+                    </p>
+                    <ul>
+                      <li>
+                        <p>
+                          Set the |algorithm| field to an
+                          `AlgorithmIdentifier` ASN.1 type with the following
+                          properties:
+                        </p>
+                        <ul>
+                          <li>
+                            <dl class="switch">
+                              <dt>If the {{Algorithm/name}} member of |keyAlgorithm| is "`MLKEM768-P256`":</dt>
+                              <dd>
+                                <p>
+                                  Set the |algorithm| object identifier to the `id-MLKEM768-ECDH-P256-SHA3-256` (1.3.6.1.5.5.7.6.59) OID.
+                                </p>
+                              </dd>
+                              <dt>If the {{Algorithm/name}} member of |keyAlgorithm| is "`MLKEM768-X25519`":</dt>
+                              <dd>
+                                <p>
+                                  Set the |algorithm| object identifier to the `id-MLKEM768-X25519-SHA3-256` (1.3.6.1.5.5.7.6.58) OID.
+                                </p>
+                              </dd>
+                              <dt>If the {{Algorithm/name}} member of |keyAlgorithm| is "`MLKEM1024-P384`":</dt>
+                              <dd>
+                                <p>
+                                  Set the |algorithm| object identifier to the `id-MLKEM1024-ECDH-P384-SHA3-256` (1.3.6.1.5.5.7.6.63) OID.
+                                </p>
+                              </dd>
+                              <dt>Otherwise:</dt>
+                              <dd>
+                                <p>
+                                  [= exception/throw =] a {{NotSupportedError}}.
+                                </p>
+                              </dd>
+                            </dl>
+                          </li>
+                        </ul>
+                      </li>
+                      <li>
+                        <p>
+                          Set the |subjectPublicKey| field to |keyData|.
+                        </p>
+                      </li>
+                    </ul>
+                  </li>
+                  <li>
+                    <p>
+                      Let |result| be the result of DER-encoding |data|.
+                    </p>
+                  </li>
+                </ol>
+              </dd>
               <dt>If |format| is {{KeyFormat/"raw-public"}}:</dt>
               <dd>
                 <ol>
@@ -9040,6 +9246,36 @@ alg: "K256" }
           </td>
           <td>
             [[CSOR]], [[RFC9935]]
+          </td>
+        </tr>
+        <tr>
+          <td>id-MLKEM768-X25519-SHA3-256 (1.3.6.1.5.5.7.6.58)</td>
+          <td>BIT STRING</td>
+          <td>
+            "`MLKEM768-X25519`"
+          </td>
+          <td>
+            [[draft-ietf-lamps-pq-composite-kem]]
+          </td>
+        </tr>
+        <tr>
+          <td>id-MLKEM768-ECDH-P256-SHA3-256 (1.3.6.1.5.5.7.6.59)</td>
+          <td>BIT STRING</td>
+          <td>
+            "`MLKEM768-P256`"
+          </td>
+          <td>
+            [[draft-ietf-lamps-pq-composite-kem]]
+          </td>
+        </tr>
+        <tr>
+          <td>id-MLKEM1024-ECDH-P384-SHA3-256 (1.3.6.1.5.5.7.6.63)</td>
+          <td>BIT STRING</td>
+          <td>
+            "`MLKEM1024-P384`"
+          </td>
+          <td>
+            [[draft-ietf-lamps-pq-composite-kem]]
           </td>
         </tr>
         <tr>

--- a/index.html
+++ b/index.html
@@ -7563,7 +7563,7 @@ dictionary Argon2Params : Algorithm {
     <section id="hybrid-kems-jwk">
       <h4>JSON Web Key Representation</h4>
       <p>
-        Hybrid KEM keys use the "AKP" (Algorithm Key Pair) key type defined in [[draft-ietf-cose-dilithium-08]]
+        Hybrid KEM keys use the "AKP" (Algorithm Key Pair) key type defined in [[RFC9964]]
         for JWK representation. The "alg" (algorithm) parameter identifies the specific hybrid KEM instance.
         The public key is carried in the "pub" parameter. If a private key is included, it is represented
         using the "priv" parameter. When expressed in JWK, all key parameters are base64url encoded.

--- a/index.html
+++ b/index.html
@@ -104,17 +104,17 @@
         "href": "https://datatracker.ietf.org/doc/draft-ietf-hpke-hpke/",
         "publisher": "IETF"
       },
-      "draft-irtf-cfrg-hybrid-kems-09": {
+      "draft-irtf-cfrg-hybrid-kems-12": {
         "title": "Hybrid PQ/T Key Encapsulation Mechanisms",
-        "href": "https://www.ietf.org/archive/id/draft-irtf-cfrg-hybrid-kems-09.html",
+        "href": "https://www.ietf.org/archive/id/draft-irtf-cfrg-hybrid-kems-12.html",
         "publisher": "IETF",
-        "date": "March 2026"
+        "date": "July 2026"
       },
-      "draft-irtf-cfrg-concrete-hybrid-kems-03": {
+      "draft-irtf-cfrg-concrete-hybrid-kems-04": {
         "title": "Concrete Hybrid PQ/T Key Encapsulation Mechanisms",
-        "href": "https://www.ietf.org/archive/id/draft-irtf-cfrg-concrete-hybrid-kems-03.html",
+        "href": "https://www.ietf.org/archive/id/draft-irtf-cfrg-concrete-hybrid-kems-04.html",
         "publisher": "IETF",
-        "date": "March 2026"
+        "date": "July 2026"
       },
     },
   };
@@ -150,7 +150,7 @@
     </p>
     <ul>
       <li><a href="#ml-kem">ML-KEM</a> [[FIPS-203]]</li>
-      <li><a href="#hybrid-kems">Hybrid KEMs</a> [[draft-irtf-cfrg-concrete-hybrid-kems-03]]</li>
+      <li><a href="#hybrid-kems">Hybrid KEMs</a> [[draft-irtf-cfrg-concrete-hybrid-kems-04]]</li>
       <li><a href="#ml-dsa">ML-DSA</a> [[FIPS-204]]</li>
       <li><a href="#slh-dsa">SLH-DSA</a> [[FIPS-205]]</li>
       <li><a href="#aes-ocb">AES-OCB</a> [[RFC7253]]</li>
@@ -2549,7 +2549,7 @@ partial dictionary JsonWebKey {
       <p>
         This describes using hybrid post-quantum/traditional key
         encapsulation mechanisms for key encapsulation and decapsulation,
-        as specified by [[draft-irtf-cfrg-concrete-hybrid-kems-03]].
+        as specified by [[draft-irtf-cfrg-concrete-hybrid-kems-04]].
       </p>
     </section>
     <section id="hybrid-kems-registration">
@@ -2628,7 +2628,7 @@ partial dictionary JsonWebKey {
               from performing the Encaps function for the hybrid
               KEM instance indicated by the {{Algorithm/name}} member of
               |algorithm| in Section 4 of
-              [[draft-irtf-cfrg-concrete-hybrid-kems-03]], using the key
+              [[draft-irtf-cfrg-concrete-hybrid-kems-04]], using the key
               represented by the <a data-cite="webcrypto#dfn-CryptoKey-slot-handle">`[[handle]]`</a>
               internal slot of |key| as the |ek| input parameter.
             </p>
@@ -2679,7 +2679,7 @@ partial dictionary JsonWebKey {
               Let |sharedKey| be the output that results from performing
               the Decaps function for the hybrid KEM instance
               indicated by the {{Algorithm/name}} member of |algorithm| in
-              Section 4 of [[draft-irtf-cfrg-concrete-hybrid-kems-03]],
+              Section 4 of [[draft-irtf-cfrg-concrete-hybrid-kems-04]],
               using the key represented by the <a data-cite="webcrypto#dfn-CryptoKey-slot-handle">`[[handle]]`</a>
               internal slot of |key| as the |dk| input parameter, and
               |ciphertext| as the |ct| input parameter.
@@ -2723,7 +2723,7 @@ partial dictionary JsonWebKey {
             <p>
               Generate a hybrid KEM key pair by performing the
               GenerateKeyPair function described in Section 5.2 of
-              [[draft-irtf-cfrg-hybrid-kems-09]] with the hybrid
+              [[draft-irtf-cfrg-hybrid-kems-12]] with the hybrid
               KEM instance indicated by the {{Algorithm/name}} member of
               |normalizedAlgorithm|.
             </p>
@@ -2866,7 +2866,7 @@ partial dictionary JsonWebKey {
                       length, `Nek`, for the hybrid KEM instance
                       indicated by the {{Algorithm/name}} member of
                       |normalizedAlgorithm| in Section 4 of
-                      [[draft-irtf-cfrg-concrete-hybrid-kems-03]], then
+                      [[draft-irtf-cfrg-concrete-hybrid-kems-04]], then
                       [= exception/throw =] a {{DataError}}.
                     </p>
                   </li>
@@ -2929,7 +2929,7 @@ partial dictionary JsonWebKey {
                     <p>
                       Let |keyPair| be the result of performing the
                       DeriveKeyPair function described in Section 5.5 of
-                      [[draft-irtf-cfrg-hybrid-kems-09]] with the
+                      [[draft-irtf-cfrg-hybrid-kems-12]] with the
                       hybrid KEM instance indicated by the {{Algorithm/name}}
                       member of |normalizedAlgorithm|, using |data| as the
                       |seed| input parameter.
@@ -3104,7 +3104,7 @@ partial dictionary JsonWebKey {
                               hybrid KEM instance indicated by the
                               {{Algorithm/name}} member of
                               |normalizedAlgorithm| in Section 4 of
-                              [[draft-irtf-cfrg-concrete-hybrid-kems-03]],
+                              [[draft-irtf-cfrg-concrete-hybrid-kems-04]],
                               then [= exception/throw =] a {{DataError}}.
                             </p>
                           </li>
@@ -8522,7 +8522,7 @@ dictionary Argon2Params : Algorithm {
       <li>
         <a href="#hybrid-kems">Hybrid KEMs</a> provide
         post-quantum/traditional KEM instances that combine ML-KEM with
-        P-256, X25519, or P-384 [[draft-irtf-cfrg-concrete-hybrid-kems-03]].
+        P-256, X25519, or P-384 [[draft-irtf-cfrg-concrete-hybrid-kems-04]].
       </li>
       <li>
         <a href="#ml-dsa">ML-DSA</a> is the primary post-quantum digital

--- a/index.html
+++ b/index.html
@@ -8658,6 +8658,45 @@ dictionary Argon2Params : Algorithm {
         <tr>
           <td>
 <pre class=js>
+{ kty: "AKP",
+alg: "MLKEM768-P256" }
+</pre>
+          </td>
+          <td>
+<pre class=js>
+{ name: "MLKEM768-P256" }
+</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>
+<pre class=js>
+{ kty: "AKP",
+alg: "MLKEM768-X25519" }
+</pre>
+          </td>
+          <td>
+<pre class=js>
+{ name: "MLKEM768-X25519" }
+</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>
+<pre class=js>
+{ kty: "AKP",
+alg: "MLKEM1024-P384" }
+</pre>
+          </td>
+          <td>
+<pre class=js>
+{ name: "MLKEM1024-P384" }
+</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>
+<pre class=js>
 { kty: "oct",
 alg: "A128OCB" }
 </pre>
@@ -8707,45 +8746,6 @@ alg: "C20P" }
           <td>
 <pre class=js>
 { name: "ChaCha20-Poly1305" }
-</pre>
-          </td>
-        </tr>
-        <tr>
-          <td>
-<pre class=js>
-{ kty: "AKP",
-alg: "MLKEM768-P256" }
-</pre>
-          </td>
-          <td>
-<pre class=js>
-{ name: "MLKEM768-P256" }
-</pre>
-          </td>
-        </tr>
-        <tr>
-          <td>
-<pre class=js>
-{ kty: "AKP",
-alg: "MLKEM768-X25519" }
-</pre>
-          </td>
-          <td>
-<pre class=js>
-{ name: "MLKEM768-X25519" }
-</pre>
-          </td>
-        </tr>
-        <tr>
-          <td>
-<pre class=js>
-{ kty: "AKP",
-alg: "MLKEM1024-P384" }
-</pre>
-          </td>
-          <td>
-<pre class=js>
-{ name: "MLKEM1024-P384" }
 </pre>
           </td>
         </tr>

--- a/index.html
+++ b/index.html
@@ -7538,6 +7538,11 @@ dictionary Argon2Params : Algorithm {
             <td>[= byte sequence =]</td>
           </tr>
           <tr>
+            <td>get shared key length</td>
+            <td>None</td>
+            <td>Integer</td>
+          </tr>
+          <tr>
             <td>generateKey</td>
             <td>None</td>
             <td>{{CryptoKeyPair}}</td>
@@ -7647,6 +7652,16 @@ dictionary Argon2Params : Algorithm {
           <li>
             <p>
               Return |sharedKey|.
+            </p>
+          </li>
+        </ol>
+      </section>
+      <section id="hybrid-kems-operations-get-shared-key-length">
+        <h5>Get shared key length</h5>
+        <ol>
+          <li>
+            <p>
+              Return 256.
             </p>
           </li>
         </ol>

--- a/index.html
+++ b/index.html
@@ -126,8 +126,11 @@
     <p>
       This specification defines a number of post-quantum secure and
       modern cryptographic algorithms for the [[webcrypto | Web Cryptography API]],
-      namely ML-KEM, Hybrid KEMs, ML-DSA, SLH-DSA, AES-OCB,
-      ChaCha20-Poly1305, SHA-3, cSHAKE, TurboSHAKE, KangarooTwelve,
+      namely ML-KEM, Hybrid KEMs,
+      ML-DSA, SLH-DSA,
+      AES-OCB, ChaCha20-Poly1305,
+      SHA-3, cSHAKE,
+      TurboSHAKE, KangarooTwelve,
       KMAC, and Argon2.
     </p>
   </section>
@@ -2497,6 +2500,771 @@ partial dictionary JsonWebKey {
                       <dd>
                         Set the {{JsonWebKey/priv}} attribute of |jwk|
                         to the base64url encoded seed represented by
+                        the <a data-cite="webcrypto#dfn-CryptoKey-slot-handle">`[[handle]]`</a>
+                        internal slot of |key|.
+                      </dd>
+                    </dl>
+                  </li>
+                  <li>
+                    <p>
+                      Set the `key_ops` attribute of |jwk| to the {{CryptoKey/usages}} attribute of |key|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the `ext` attribute of |jwk| to the <a data-cite="webcrypto#dfn-CryptoKey-slot-extractable">`[[extractable]]`</a> internal slot
+                      of |key|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |result| be |jwk|.
+                    </p>
+                  </li>
+                </ol>
+              </dd>
+              <dt>Otherwise:</dt>
+              <dd>
+                <p>
+                  [= exception/throw =] a
+                  {{NotSupportedError}}.
+                </p>
+              </dd>
+            </dl>
+          </li>
+          <li>
+            <p>
+              Return |result|.
+            </p>
+          </li>
+        </ol>
+      </section>
+    </section>
+  </section>
+
+  <section id="hybrid-kems">
+    <h3>Hybrid KEMs</h3>
+    <section id="hybrid-kems-description" class="informative">
+      <h4>Description</h4>
+      <p>
+        This describes using hybrid post-quantum/traditional key
+        encapsulation mechanisms for key encapsulation and decapsulation,
+        as specified by [[draft-irtf-cfrg-concrete-hybrid-kems-03]].
+      </p>
+    </section>
+    <section id="hybrid-kems-registration">
+      <h4>Registration</h4>
+      <p>
+        The <a data-cite="webcrypto#recognized-algorithm-name">recognized algorithm names</a> for
+        this algorithm are "`MLKEM768-P256`", "`MLKEM768-X25519`" and
+        "`MLKEM1024-P384`".
+      </p>
+      <table>
+        <thead>
+          <tr>
+            <th><a data-cite="webcrypto#supported-operations">Operation</a></th>
+            <th><a data-cite="webcrypto#algorithm-specific-params">Parameters</a></th>
+            <th><a data-cite="webcrypto#algorithm-result">Result</a></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>encapsulate</td>
+            <td>None</td>
+            <td>{{EncapsulatedBits}}</td>
+          </tr>
+          <tr>
+            <td>decapsulate</td>
+            <td>None</td>
+            <td>[= byte sequence =]</td>
+          </tr>
+          <tr>
+            <td>get shared key length</td>
+            <td>None</td>
+            <td>Integer</td>
+          </tr>
+          <tr>
+            <td>generateKey</td>
+            <td>None</td>
+            <td>{{CryptoKeyPair}}</td>
+          </tr>
+          <tr>
+            <td>importKey</td>
+            <td>None</td>
+            <td>{{CryptoKey}}</td>
+          </tr>
+          <tr>
+            <td>exportKey</td>
+            <td>None</td>
+            <td>object</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+    <section id="hybrid-kems-jwk">
+      <h4>JSON Web Key Representation</h4>
+      <p>
+        Hybrid KEM keys use the "AKP" (Algorithm Key Pair) key type defined in [[RFC9964]]
+        for JWK representation. The "alg" (algorithm) parameter identifies the specific hybrid KEM instance.
+        The public key is carried in the "pub" parameter. If a private key is included, it is represented
+        using the "priv" parameter. When expressed in JWK, all key parameters are base64url encoded.
+      </p>
+    </section>
+
+    <section id="hybrid-kems-operations">
+      <h4>Operations</h4>
+      <section id="hybrid-kems-operations-encapsulate">
+        <h5>Encapsulate</h5>
+        <ol>
+          <li>
+            <p>
+              If the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot of
+              |key| is not {{KeyType/"public"}}, then [= exception/throw =] an {{InvalidAccessError}}.
+            </p>
+          </li>
+          <li>
+            <p>
+              Let |sharedKey| and |ciphertext| be the outputs that result
+              from performing the Encaps function for the hybrid
+              KEM instance indicated by the {{Algorithm/name}} member of
+              |algorithm| in Section 4 of
+              [[draft-irtf-cfrg-concrete-hybrid-kems-03]], using the key
+              represented by the <a data-cite="webcrypto#dfn-CryptoKey-slot-handle">`[[handle]]`</a>
+              internal slot of |key| as the |ek| input parameter.
+            </p>
+          </li>
+          <li>
+            <p>
+              If the Encaps function returned an error, return an {{OperationError}}.
+            </p>
+          </li>
+          <li>
+            <p>
+              Let |result| be a new {{EncapsulatedBits}}
+              dictionary.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the {{EncapsulatedBits/sharedKey}} attribute
+              of |result| to the result of [= ArrayBuffer/create | creating =]
+              an {{ArrayBuffer}} containing |sharedKey|.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the {{EncapsulatedBits/ciphertext}} attribute
+              of |result| to the result of [= ArrayBuffer/create | creating =]
+              an {{ArrayBuffer}} containing |ciphertext|.
+            </p>
+          </li>
+          <li>
+            <p>
+              Return |result|.
+            </p>
+          </li>
+        </ol>
+      </section>
+      <section id="hybrid-kems-operations-decapsulate">
+        <h5>Decapsulate</h5>
+        <ol>
+          <li>
+            <p>
+              If the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot of
+              |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
+            </p>
+          </li>
+          <li>
+            <p>
+              Let |sharedKey| be the output that results from performing
+              the Decaps function for the hybrid KEM instance
+              indicated by the {{Algorithm/name}} member of |algorithm| in
+              Section 4 of [[draft-irtf-cfrg-concrete-hybrid-kems-03]],
+              using the key represented by the <a data-cite="webcrypto#dfn-CryptoKey-slot-handle">`[[handle]]`</a>
+              internal slot of |key| as the |dk| input parameter, and
+              |ciphertext| as the |ct| input parameter.
+            </p>
+          </li>
+          <li>
+            <p>
+              If the Decaps function returned an error, return an {{OperationError}}.
+            </p>
+          </li>
+          <li>
+            <p>
+              Return |sharedKey|.
+            </p>
+          </li>
+        </ol>
+      </section>
+      <section id="hybrid-kems-operations-get-shared-key-length">
+        <h5>Get shared key length</h5>
+        <ol>
+          <li>
+            <p>
+              Return 256.
+            </p>
+          </li>
+        </ol>
+      </section>
+      <section id="hybrid-kems-operations-generate-key">
+        <h5>Generate Key</h5>
+        <ol>
+          <li>
+            <p>
+              If |usages| contains an entry which is not
+              one of "`encapsulateKey`", "`encapsulateBits`",
+              "`decapsulateKey`" or "`decapsulateBits`",
+              then [= exception/throw =] a
+              {{SyntaxError}}.
+            </p>
+          </li>
+          <li>
+            <p>
+              Generate a hybrid KEM key pair by performing the
+              GenerateKeyPair function described in Section 5.2 of
+              [[draft-irtf-cfrg-hybrid-kems-09]] with the hybrid
+              KEM instance indicated by the {{Algorithm/name}} member of
+              |normalizedAlgorithm|.
+            </p>
+          </li>
+          <li>
+            <p>
+              If the key generation step fails,
+              then [= exception/throw =] an
+              {{OperationError}}.
+            </p>
+          </li>
+          <li>
+            <p>
+              Let |algorithm| be a new {{KeyAlgorithm}} object.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the {{KeyAlgorithm/name}} attribute of
+              |algorithm| to the {{Algorithm/name}} attribute of
+              |normalizedAlgorithm|.
+            </p>
+          </li>
+          <li>
+            <p>
+              Let |publicKey| be a new {{CryptoKey}}
+              representing the encapsulation key of the generated key pair.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot of
+              |publicKey| to {{KeyType/"public"}}.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-algorithm">`[[algorithm]]`</a> internal
+              slot of |publicKey| to |algorithm|.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-extractable">`[[extractable]]`</a> internal
+              slot of |publicKey| to true.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-usages">`[[usages]]`</a> internal slot of
+              |publicKey| to be the
+              <a data-cite="webcrypto#concept-usage-intersection">usage intersection</a> of
+              |usages| and `[ "encapsulateKey", "encapsulateBits" ]`.
+            </p>
+          </li>
+          <li>
+            <p>
+              Let |privateKey| be a new {{CryptoKey}}
+              representing the decapsulation key of the generated key pair.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot of
+              |privateKey| to {{KeyType/"private"}}.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-algorithm">`[[algorithm]]`</a> internal
+              slot of |privateKey| to |algorithm|.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-extractable">`[[extractable]]`</a> internal
+              slot of |privateKey| to |extractable|.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-usages">`[[usages]]`</a> internal slot of
+              |privateKey| to be the
+              <a data-cite="webcrypto#concept-usage-intersection">usage intersection</a> of
+              |usages| and `[ "decapsulateKey", "decapsulateBits" ]`.
+            </p>
+          </li>
+          <li>
+            <p>
+              Let |result| be a new {{CryptoKeyPair}}
+              dictionary.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the {{CryptoKeyPair/publicKey}} attribute
+              of |result| to be |publicKey|.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the {{CryptoKeyPair/privateKey}} attribute
+              of |result| to be |privateKey|.
+            </p>
+          </li>
+          <li>
+            <p>
+              Return |result|.
+            </p>
+          </li>
+        </ol>
+      </section>
+      <section id="hybrid-kems-operations-import-key">
+        <h5>Import Key</h5>
+        <ol>
+          <li>
+            <p>Let |keyData| be the key data to be imported.</p>
+          </li>
+          <li>
+            <dl class="switch">
+              <dt>If |format| is {{KeyFormat/"raw-public"}}:</dt>
+              <dd>
+                <ol>
+                  <li>
+                    <p>
+                      If |usages| contains an entry which is not
+                      "`encapsulateKey`" or "`encapsulateBits`"
+                      then [= exception/throw =] a
+                      {{SyntaxError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |data| be |keyData|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the length in bytes of |data| is not the raw public key
+                      length, `Nek`, for the hybrid KEM instance
+                      indicated by the {{Algorithm/name}} member of
+                      |normalizedAlgorithm| in Section 4 of
+                      [[draft-irtf-cfrg-concrete-hybrid-kems-03]], then
+                      [= exception/throw =] a {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |key| be a new {{CryptoKey}}
+                      that represents the hybrid KEM public key data in |data|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot
+                      of |key| to {{KeyType/"public"}}
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |algorithm| be a new {{KeyAlgorithm}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the {{KeyAlgorithm/name}} attribute of
+                      |algorithm| to the {{Algorithm/name}} attribute of
+                      |normalizedAlgorithm|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-algorithm">`[[algorithm]]`</a>
+                      internal slot of |key| to |algorithm|.
+                    </p>
+                  </li>
+                </ol>
+              </dd>
+              <dt>If |format| is {{KeyFormat/"raw-seed"}}:</dt>
+              <dd>
+                <ol>
+                  <li>
+                    <p>
+                      If |usages| contains an entry which is not
+                      "`decapsulateKey`" or "`decapsulateBits`"
+                      then [= exception/throw =] a
+                      {{SyntaxError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |data| be |keyData|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the length in bits of |data| is not 256
+                      then [= exception/throw =] a
+                      {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |keyPair| be the result of performing the
+                      DeriveKeyPair function described in Section 5.5 of
+                      [[draft-irtf-cfrg-hybrid-kems-09]] with the
+                      hybrid KEM instance indicated by the {{Algorithm/name}}
+                      member of |normalizedAlgorithm|, using |data| as the
+                      |seed| input parameter.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the DeriveKeyPair function returned an error,
+                      then [= exception/throw =] an {{OperationError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |key| be a new {{CryptoKey}}
+                      that represents the hybrid KEM private key identified by
+                      the decapsulation key of |keyPair|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot
+                      of |key| to {{KeyType/"private"}}
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |algorithm| be a new {{KeyAlgorithm}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the {{KeyAlgorithm/name}} attribute of
+                      |algorithm| to the {{Algorithm/name}} attribute of
+                      |normalizedAlgorithm|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-algorithm">`[[algorithm]]`</a>
+                      internal slot of |key| to |algorithm|.
+                    </p>
+                  </li>
+                </ol>
+              </dd>
+              <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
+              <dd>
+                <ol>
+                  <li>
+                    <dl class="switch">
+                      <dt>If |keyData| is a {{JsonWebKey}} dictionary:</dt>
+                      <dd><p>Let |jwk| equal |keyData|.</p></dd>
+                      <dt>Otherwise:</dt>
+                      <dd><p>[= exception/Throw =] a {{DataError}}.</p></dd>
+                    </dl>
+                  </li>
+                  <li>
+                    <p>
+                      If the {{JsonWebKey/priv}} field of |jwk| is present
+                      and if |usages| contains an entry which is not
+                      "`decapsulateKey`" or "`decapsulateBits`"
+                      then [= exception/throw =] a
+                      {{SyntaxError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the {{JsonWebKey/priv}} field of |jwk| is not present
+                      and if |usages| contains an entry which is not
+                      "`encapsulateKey`" or "`encapsulateBits`"
+                      then [= exception/throw =] a
+                      {{SyntaxError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the {{JsonWebKey/kty}} field of |jwk| is not
+                      "`AKP`",
+                      then [= exception/throw =] a
+                      {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the {{JsonWebKey/alg}} field of |jwk| is not present,
+                      or its value does not identify the hybrid KEM instance
+                      indicated by the {{Algorithm/name}} member of
+                      |normalizedAlgorithm|,
+                      then [= exception/throw =] a
+                      {{DataError}}.
+                    </p>
+                    <p class="note">
+                      The "alg" values registered in the
+                      IANA JSON Web Signature and Encryption Algorithms registry
+                      for the hybrid KEM instances defined by this specification
+                      are `MLKEM768-P256`, `MLKEM768-X25519`, and
+                      `MLKEM1024-P384`. Implementations should also accept other
+                      values from this registry that identify an algorithm
+                      utilizing the same hybrid KEM instance.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If |usages| is non-empty and the {{JsonWebKey/use}} field of |jwk| is present
+                      and is not equal to "`enc`", then [= exception/throw =] a
+                      {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the {{JsonWebKey/key_ops}} field of |jwk| is present, and
+                      is invalid according to the requirements of JSON Web
+                      Key [[JWK]], or it does not contain all of the specified |usages|
+                      values,
+                      then [= exception/throw =] a
+                      {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the {{JsonWebKey/ext}} field of |jwk| is present and
+                      has the value false and |extractable| is true,
+                      then [= exception/throw =] a
+                      {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <dl class="switch">
+                      <dt>If the {{JsonWebKey/priv}} field of |jwk| is present:</dt>
+                      <dd>
+                        <ol>
+                          <li>
+                            <p>
+                              If the {{JsonWebKey/priv}} attribute of |jwk|
+                              does not contain a valid base64url encoded
+                              32-byte seed representing a hybrid KEM private key,
+                              then [= exception/throw =] a {{DataError}}.
+                            </p>
+                          </li>
+                          <li>
+                            <p>
+                              Let |key| be a new {{CryptoKey}} object that represents the
+                              hybrid KEM private key identified by interpreting the
+                              {{JsonWebKey/priv}} attribute of |jwk|
+                              as a base64url encoded seed.
+                            </p>
+                          </li>
+                          <li>
+                            <p>
+                              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a>
+                              internal slot of |key| to {{KeyType/"private"}}.
+                            </p>
+                          </li>
+                          <li>
+                            <p>
+                              If the {{JsonWebKey/pub}} attribute of |jwk|
+                              does not contain the base64url encoded public key
+                              representing the hybrid KEM public key
+                              corresponding to |key|,
+                              then [= exception/throw =] a {{DataError}}.
+                            </p>
+                          </li>
+                        </ol>
+                      </dd>
+                      <dt>Otherwise:</dt>
+                      <dd>
+                        <ol>
+                          <li>
+                            <p>
+                              If the {{JsonWebKey/pub}} attribute of |jwk|
+                              does not contain a valid base64url encoded raw
+                              public key whose length is `Nek` for the
+                              hybrid KEM instance indicated by the
+                              {{Algorithm/name}} member of
+                              |normalizedAlgorithm| in Section 4 of
+                              [[draft-irtf-cfrg-concrete-hybrid-kems-03]],
+                              then [= exception/throw =] a {{DataError}}.
+                            </p>
+                          </li>
+                          <li>
+                            <p>
+                              Let |key| be a new {{CryptoKey}} object that represents the
+                              hybrid KEM public key identified by interpreting the
+                              {{JsonWebKey/pub}} attribute of |jwk|
+                              as a base64url encoded public key.
+                            </p>
+                          </li>
+                          <li>
+                            <p>
+                              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a>
+                              internal slot of |key| to {{KeyType/"public"}}.
+                            </p>
+                          </li>
+                        </ol>
+                      </dd>
+                    </dl>
+                  </li>
+                  <li>
+                    <p>
+                      Let |algorithm| be a new instance of a {{KeyAlgorithm}} object.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the {{KeyAlgorithm/name}} attribute of
+                      |algorithm| to the {{Algorithm/name}} member of |normalizedAlgorithm|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-algorithm">`[[algorithm]]`</a>
+                      internal slot of |key| to |algorithm|.
+                    </p>
+                  </li>
+                </ol>
+              </dd>
+              <dt>Otherwise:</dt>
+              <dd>
+                [= exception/throw =] a
+                {{NotSupportedError}}.
+              </dd>
+            </dl>
+          </li>
+          <li>
+            <p>
+              Return |key|.
+            </p>
+          </li>
+        </ol>
+      </section>
+      <section id="hybrid-kems-operations-export-key">
+        <h5>Export Key</h5>
+        <ol>
+          <li>
+            <p>
+              Let |key| be the {{CryptoKey}} to be
+              exported.
+            </p>
+          </li>
+          <li>
+            <p>
+              If the underlying cryptographic key material represented by the <a data-cite="webcrypto#dfn-CryptoKey-slot-handle">`[[handle]]`</a> internal slot of |key|
+              cannot be accessed, then [= exception/throw =] an {{OperationError}}.
+            </p>
+          </li>
+          <li>
+            <dl class="switch">
+              <dt>If |format| is {{KeyFormat/"raw-public"}}:</dt>
+              <dd>
+                <ol>
+                  <li>
+                    <p>
+                      If the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot
+                      of |key| is not {{KeyType/"public"}}, then [= exception/throw =] an {{InvalidAccessError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |data| be a [= byte sequence =] containing
+                      the raw octets of the key represented by the <a data-cite="webcrypto#dfn-CryptoKey-slot-handle">`[[handle]]`</a> internal slot of
+                      |key|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |result| be |data|.
+                    </p>
+                  </li>
+                </ol>
+              </dd>
+              <dt>If |format| is {{KeyFormat/"raw-seed"}}:</dt>
+              <dd>
+                <ol>
+                  <li>
+                    <p>
+                      If the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot
+                      of |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |data| be a [= byte sequence =] containing the 32-byte seed represented by
+                      the <a data-cite="webcrypto#dfn-CryptoKey-slot-handle">`[[handle]]`</a>
+                      internal slot of |key|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |result| be |data|.
+                    </p>
+                  </li>
+                </ol>
+              </dd>
+              <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
+              <dd>
+                <ol>
+                  <li>
+                    <p>
+                      Let |jwk| be a new {{JsonWebKey}}
+                      dictionary.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |keyAlgorithm| be the <a data-cite="webcrypto#dfn-CryptoKey-slot-algorithm">`[[algorithm]]`</a> internal slot of |key|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the `kty` attribute of |jwk| to
+                      "`AKP`".
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the `alg` attribute of |jwk| to the
+                      {{Algorithm/name}} member of |keyAlgorithm|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the {{JsonWebKey/pub}} attribute of |jwk|
+                      to the base64url encoded public key corresponding
+                      to the <a data-cite="webcrypto#dfn-CryptoKey-slot-handle">`[[handle]]`</a>
+                      internal slot of |key|.
+                    </p>
+                  </li>
+                  <li>
+                    <dl class="switch">
+                      <dt>
+                        If the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot
+                        of |key| is {{KeyType/"private"}}:
+                      </dt>
+                      <dd>
+                        Set the {{JsonWebKey/priv}} attribute of |jwk|
+                        to the base64url encoded 32-byte seed represented by
                         the <a data-cite="webcrypto#dfn-CryptoKey-slot-handle">`[[handle]]`</a>
                         internal slot of |key|.
                       </dd>
@@ -7494,771 +8262,6 @@ dictionary Argon2Params : Algorithm {
           <li>
             <p>
               Return null.
-            </p>
-          </li>
-        </ol>
-      </section>
-    </section>
-  </section>
-
-  <section id="hybrid-kems">
-    <h3>Hybrid KEMs</h3>
-    <section id="hybrid-kems-description" class="informative">
-      <h4>Description</h4>
-      <p>
-        This describes using hybrid post-quantum/traditional key
-        encapsulation mechanisms for key encapsulation and decapsulation,
-        as specified by [[draft-irtf-cfrg-concrete-hybrid-kems-03]].
-      </p>
-    </section>
-    <section id="hybrid-kems-registration">
-      <h4>Registration</h4>
-      <p>
-        The <a data-cite="webcrypto#recognized-algorithm-name">recognized algorithm names</a> for
-        this algorithm are "`MLKEM768-P256`", "`MLKEM768-X25519`" and
-        "`MLKEM1024-P384`".
-      </p>
-      <table>
-        <thead>
-          <tr>
-            <th><a data-cite="webcrypto#supported-operations">Operation</a></th>
-            <th><a data-cite="webcrypto#algorithm-specific-params">Parameters</a></th>
-            <th><a data-cite="webcrypto#algorithm-result">Result</a></th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>encapsulate</td>
-            <td>None</td>
-            <td>{{EncapsulatedBits}}</td>
-          </tr>
-          <tr>
-            <td>decapsulate</td>
-            <td>None</td>
-            <td>[= byte sequence =]</td>
-          </tr>
-          <tr>
-            <td>get shared key length</td>
-            <td>None</td>
-            <td>Integer</td>
-          </tr>
-          <tr>
-            <td>generateKey</td>
-            <td>None</td>
-            <td>{{CryptoKeyPair}}</td>
-          </tr>
-          <tr>
-            <td>importKey</td>
-            <td>None</td>
-            <td>{{CryptoKey}}</td>
-          </tr>
-          <tr>
-            <td>exportKey</td>
-            <td>None</td>
-            <td>object</td>
-          </tr>
-        </tbody>
-      </table>
-    </section>
-    <section id="hybrid-kems-jwk">
-      <h4>JSON Web Key Representation</h4>
-      <p>
-        Hybrid KEM keys use the "AKP" (Algorithm Key Pair) key type defined in [[RFC9964]]
-        for JWK representation. The "alg" (algorithm) parameter identifies the specific hybrid KEM instance.
-        The public key is carried in the "pub" parameter. If a private key is included, it is represented
-        using the "priv" parameter. When expressed in JWK, all key parameters are base64url encoded.
-      </p>
-    </section>
-
-    <section id="hybrid-kems-operations">
-      <h4>Operations</h4>
-      <section id="hybrid-kems-operations-encapsulate">
-        <h5>Encapsulate</h5>
-        <ol>
-          <li>
-            <p>
-              If the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot of
-              |key| is not {{KeyType/"public"}}, then [= exception/throw =] an {{InvalidAccessError}}.
-            </p>
-          </li>
-          <li>
-            <p>
-              Let |sharedKey| and |ciphertext| be the outputs that result
-              from performing the Encaps function for the hybrid
-              KEM instance indicated by the {{Algorithm/name}} member of
-              |algorithm| in Section 4 of
-              [[draft-irtf-cfrg-concrete-hybrid-kems-03]], using the key
-              represented by the <a data-cite="webcrypto#dfn-CryptoKey-slot-handle">`[[handle]]`</a>
-              internal slot of |key| as the |ek| input parameter.
-            </p>
-          </li>
-          <li>
-            <p>
-              If the Encaps function returned an error, return an {{OperationError}}.
-            </p>
-          </li>
-          <li>
-            <p>
-              Let |result| be a new {{EncapsulatedBits}}
-              dictionary.
-            </p>
-          </li>
-          <li>
-            <p>
-              Set the {{EncapsulatedBits/sharedKey}} attribute
-              of |result| to the result of [= ArrayBuffer/create | creating =]
-              an {{ArrayBuffer}} containing |sharedKey|.
-            </p>
-          </li>
-          <li>
-            <p>
-              Set the {{EncapsulatedBits/ciphertext}} attribute
-              of |result| to the result of [= ArrayBuffer/create | creating =]
-              an {{ArrayBuffer}} containing |ciphertext|.
-            </p>
-          </li>
-          <li>
-            <p>
-              Return |result|.
-            </p>
-          </li>
-        </ol>
-      </section>
-      <section id="hybrid-kems-operations-decapsulate">
-        <h5>Decapsulate</h5>
-        <ol>
-          <li>
-            <p>
-              If the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot of
-              |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
-            </p>
-          </li>
-          <li>
-            <p>
-              Let |sharedKey| be the output that results from performing
-              the Decaps function for the hybrid KEM instance
-              indicated by the {{Algorithm/name}} member of |algorithm| in
-              Section 4 of [[draft-irtf-cfrg-concrete-hybrid-kems-03]],
-              using the key represented by the <a data-cite="webcrypto#dfn-CryptoKey-slot-handle">`[[handle]]`</a>
-              internal slot of |key| as the |dk| input parameter, and
-              |ciphertext| as the |ct| input parameter.
-            </p>
-          </li>
-          <li>
-            <p>
-              If the Decaps function returned an error, return an {{OperationError}}.
-            </p>
-          </li>
-          <li>
-            <p>
-              Return |sharedKey|.
-            </p>
-          </li>
-        </ol>
-      </section>
-      <section id="hybrid-kems-operations-get-shared-key-length">
-        <h5>Get shared key length</h5>
-        <ol>
-          <li>
-            <p>
-              Return 256.
-            </p>
-          </li>
-        </ol>
-      </section>
-      <section id="hybrid-kems-operations-generate-key">
-        <h5>Generate Key</h5>
-        <ol>
-          <li>
-            <p>
-              If |usages| contains an entry which is not
-              one of "`encapsulateKey`", "`encapsulateBits`",
-              "`decapsulateKey`" or "`decapsulateBits`",
-              then [= exception/throw =] a
-              {{SyntaxError}}.
-            </p>
-          </li>
-          <li>
-            <p>
-              Generate a hybrid KEM key pair by performing the
-              GenerateKeyPair function described in Section 5.2 of
-              [[draft-irtf-cfrg-hybrid-kems-09]] with the hybrid
-              KEM instance indicated by the {{Algorithm/name}} member of
-              |normalizedAlgorithm|.
-            </p>
-          </li>
-          <li>
-            <p>
-              If the key generation step fails,
-              then [= exception/throw =] an
-              {{OperationError}}.
-            </p>
-          </li>
-          <li>
-            <p>
-              Let |algorithm| be a new {{KeyAlgorithm}} object.
-            </p>
-          </li>
-          <li>
-            <p>
-              Set the {{KeyAlgorithm/name}} attribute of
-              |algorithm| to the {{Algorithm/name}} attribute of
-              |normalizedAlgorithm|.
-            </p>
-          </li>
-          <li>
-            <p>
-              Let |publicKey| be a new {{CryptoKey}}
-              representing the encapsulation key of the generated key pair.
-            </p>
-          </li>
-          <li>
-            <p>
-              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot of
-              |publicKey| to {{KeyType/"public"}}.
-            </p>
-          </li>
-          <li>
-            <p>
-              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-algorithm">`[[algorithm]]`</a> internal
-              slot of |publicKey| to |algorithm|.
-            </p>
-          </li>
-          <li>
-            <p>
-              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-extractable">`[[extractable]]`</a> internal
-              slot of |publicKey| to true.
-            </p>
-          </li>
-          <li>
-            <p>
-              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-usages">`[[usages]]`</a> internal slot of
-              |publicKey| to be the
-              <a data-cite="webcrypto#concept-usage-intersection">usage intersection</a> of
-              |usages| and `[ "encapsulateKey", "encapsulateBits" ]`.
-            </p>
-          </li>
-          <li>
-            <p>
-              Let |privateKey| be a new {{CryptoKey}}
-              representing the decapsulation key of the generated key pair.
-            </p>
-          </li>
-          <li>
-            <p>
-              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot of
-              |privateKey| to {{KeyType/"private"}}.
-            </p>
-          </li>
-          <li>
-            <p>
-              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-algorithm">`[[algorithm]]`</a> internal
-              slot of |privateKey| to |algorithm|.
-            </p>
-          </li>
-          <li>
-            <p>
-              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-extractable">`[[extractable]]`</a> internal
-              slot of |privateKey| to |extractable|.
-            </p>
-          </li>
-          <li>
-            <p>
-              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-usages">`[[usages]]`</a> internal slot of
-              |privateKey| to be the
-              <a data-cite="webcrypto#concept-usage-intersection">usage intersection</a> of
-              |usages| and `[ "decapsulateKey", "decapsulateBits" ]`.
-            </p>
-          </li>
-          <li>
-            <p>
-              Let |result| be a new {{CryptoKeyPair}}
-              dictionary.
-            </p>
-          </li>
-          <li>
-            <p>
-              Set the {{CryptoKeyPair/publicKey}} attribute
-              of |result| to be |publicKey|.
-            </p>
-          </li>
-          <li>
-            <p>
-              Set the {{CryptoKeyPair/privateKey}} attribute
-              of |result| to be |privateKey|.
-            </p>
-          </li>
-          <li>
-            <p>
-              Return |result|.
-            </p>
-          </li>
-        </ol>
-      </section>
-      <section id="hybrid-kems-operations-import-key">
-        <h5>Import Key</h5>
-        <ol>
-          <li>
-            <p>Let |keyData| be the key data to be imported.</p>
-          </li>
-          <li>
-            <dl class="switch">
-              <dt>If |format| is {{KeyFormat/"raw-public"}}:</dt>
-              <dd>
-                <ol>
-                  <li>
-                    <p>
-                      If |usages| contains an entry which is not
-                      "`encapsulateKey`" or "`encapsulateBits`"
-                      then [= exception/throw =] a
-                      {{SyntaxError}}.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Let |data| be |keyData|.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      If the length in bytes of |data| is not the raw public key
-                      length, `Nek`, for the hybrid KEM instance
-                      indicated by the {{Algorithm/name}} member of
-                      |normalizedAlgorithm| in Section 4 of
-                      [[draft-irtf-cfrg-concrete-hybrid-kems-03]], then
-                      [= exception/throw =] a {{DataError}}.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Let |key| be a new {{CryptoKey}}
-                      that represents the hybrid KEM public key data in |data|.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot
-                      of |key| to {{KeyType/"public"}}
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Let |algorithm| be a new {{KeyAlgorithm}}.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Set the {{KeyAlgorithm/name}} attribute of
-                      |algorithm| to the {{Algorithm/name}} attribute of
-                      |normalizedAlgorithm|.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-algorithm">`[[algorithm]]`</a>
-                      internal slot of |key| to |algorithm|.
-                    </p>
-                  </li>
-                </ol>
-              </dd>
-              <dt>If |format| is {{KeyFormat/"raw-seed"}}:</dt>
-              <dd>
-                <ol>
-                  <li>
-                    <p>
-                      If |usages| contains an entry which is not
-                      "`decapsulateKey`" or "`decapsulateBits`"
-                      then [= exception/throw =] a
-                      {{SyntaxError}}.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Let |data| be |keyData|.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      If the length in bits of |data| is not 256
-                      then [= exception/throw =] a
-                      {{DataError}}.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Let |keyPair| be the result of performing the
-                      DeriveKeyPair function described in Section 5.5 of
-                      [[draft-irtf-cfrg-hybrid-kems-09]] with the
-                      hybrid KEM instance indicated by the {{Algorithm/name}}
-                      member of |normalizedAlgorithm|, using |data| as the
-                      |seed| input parameter.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      If the DeriveKeyPair function returned an error,
-                      then [= exception/throw =] an {{OperationError}}.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Let |key| be a new {{CryptoKey}}
-                      that represents the hybrid KEM private key identified by
-                      the decapsulation key of |keyPair|.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot
-                      of |key| to {{KeyType/"private"}}
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Let |algorithm| be a new {{KeyAlgorithm}}.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Set the {{KeyAlgorithm/name}} attribute of
-                      |algorithm| to the {{Algorithm/name}} attribute of
-                      |normalizedAlgorithm|.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-algorithm">`[[algorithm]]`</a>
-                      internal slot of |key| to |algorithm|.
-                    </p>
-                  </li>
-                </ol>
-              </dd>
-              <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
-              <dd>
-                <ol>
-                  <li>
-                    <dl class="switch">
-                      <dt>If |keyData| is a {{JsonWebKey}} dictionary:</dt>
-                      <dd><p>Let |jwk| equal |keyData|.</p></dd>
-                      <dt>Otherwise:</dt>
-                      <dd><p>[= exception/Throw =] a {{DataError}}.</p></dd>
-                    </dl>
-                  </li>
-                  <li>
-                    <p>
-                      If the {{JsonWebKey/priv}} field of |jwk| is present
-                      and if |usages| contains an entry which is not
-                      "`decapsulateKey`" or "`decapsulateBits`"
-                      then [= exception/throw =] a
-                      {{SyntaxError}}.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      If the {{JsonWebKey/priv}} field of |jwk| is not present
-                      and if |usages| contains an entry which is not
-                      "`encapsulateKey`" or "`encapsulateBits`"
-                      then [= exception/throw =] a
-                      {{SyntaxError}}.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      If the {{JsonWebKey/kty}} field of |jwk| is not
-                      "`AKP`",
-                      then [= exception/throw =] a
-                      {{DataError}}.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      If the {{JsonWebKey/alg}} field of |jwk| is not present,
-                      or its value does not identify the hybrid KEM instance
-                      indicated by the {{Algorithm/name}} member of
-                      |normalizedAlgorithm|,
-                      then [= exception/throw =] a
-                      {{DataError}}.
-                    </p>
-                    <p class="note">
-                      The "alg" values registered in the
-                      IANA JSON Web Signature and Encryption Algorithms registry
-                      for the hybrid KEM instances defined by this specification
-                      are `MLKEM768-P256`, `MLKEM768-X25519`, and
-                      `MLKEM1024-P384`. Implementations should also accept other
-                      values from this registry that identify an algorithm
-                      utilizing the same hybrid KEM instance.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      If |usages| is non-empty and the {{JsonWebKey/use}} field of |jwk| is present
-                      and is not equal to "`enc`", then [= exception/throw =] a
-                      {{DataError}}.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      If the {{JsonWebKey/key_ops}} field of |jwk| is present, and
-                      is invalid according to the requirements of JSON Web
-                      Key [[JWK]], or it does not contain all of the specified |usages|
-                      values,
-                      then [= exception/throw =] a
-                      {{DataError}}.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      If the {{JsonWebKey/ext}} field of |jwk| is present and
-                      has the value false and |extractable| is true,
-                      then [= exception/throw =] a
-                      {{DataError}}.
-                    </p>
-                  </li>
-                  <li>
-                    <dl class="switch">
-                      <dt>If the {{JsonWebKey/priv}} field of |jwk| is present:</dt>
-                      <dd>
-                        <ol>
-                          <li>
-                            <p>
-                              If the {{JsonWebKey/priv}} attribute of |jwk|
-                              does not contain a valid base64url encoded
-                              32-byte seed representing a hybrid KEM private key,
-                              then [= exception/throw =] a {{DataError}}.
-                            </p>
-                          </li>
-                          <li>
-                            <p>
-                              Let |key| be a new {{CryptoKey}} object that represents the
-                              hybrid KEM private key identified by interpreting the
-                              {{JsonWebKey/priv}} attribute of |jwk|
-                              as a base64url encoded seed.
-                            </p>
-                          </li>
-                          <li>
-                            <p>
-                              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a>
-                              internal slot of |key| to {{KeyType/"private"}}.
-                            </p>
-                          </li>
-                          <li>
-                            <p>
-                              If the {{JsonWebKey/pub}} attribute of |jwk|
-                              does not contain the base64url encoded public key
-                              representing the hybrid KEM public key
-                              corresponding to |key|,
-                              then [= exception/throw =] a {{DataError}}.
-                            </p>
-                          </li>
-                        </ol>
-                      </dd>
-                      <dt>Otherwise:</dt>
-                      <dd>
-                        <ol>
-                          <li>
-                            <p>
-                              If the {{JsonWebKey/pub}} attribute of |jwk|
-                              does not contain a valid base64url encoded raw
-                              public key whose length is `Nek` for the
-                              hybrid KEM instance indicated by the
-                              {{Algorithm/name}} member of
-                              |normalizedAlgorithm| in Section 4 of
-                              [[draft-irtf-cfrg-concrete-hybrid-kems-03]],
-                              then [= exception/throw =] a {{DataError}}.
-                            </p>
-                          </li>
-                          <li>
-                            <p>
-                              Let |key| be a new {{CryptoKey}} object that represents the
-                              hybrid KEM public key identified by interpreting the
-                              {{JsonWebKey/pub}} attribute of |jwk|
-                              as a base64url encoded public key.
-                            </p>
-                          </li>
-                          <li>
-                            <p>
-                              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a>
-                              internal slot of |key| to {{KeyType/"public"}}.
-                            </p>
-                          </li>
-                        </ol>
-                      </dd>
-                    </dl>
-                  </li>
-                  <li>
-                    <p>
-                      Let |algorithm| be a new instance of a {{KeyAlgorithm}} object.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Set the {{KeyAlgorithm/name}} attribute of
-                      |algorithm| to the {{Algorithm/name}} member of |normalizedAlgorithm|.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-algorithm">`[[algorithm]]`</a>
-                      internal slot of |key| to |algorithm|.
-                    </p>
-                  </li>
-                </ol>
-              </dd>
-              <dt>Otherwise:</dt>
-              <dd>
-                [= exception/throw =] a
-                {{NotSupportedError}}.
-              </dd>
-            </dl>
-          </li>
-          <li>
-            <p>
-              Return |key|.
-            </p>
-          </li>
-        </ol>
-      </section>
-      <section id="hybrid-kems-operations-export-key">
-        <h5>Export Key</h5>
-        <ol>
-          <li>
-            <p>
-              Let |key| be the {{CryptoKey}} to be
-              exported.
-            </p>
-          </li>
-          <li>
-            <p>
-              If the underlying cryptographic key material represented by the <a data-cite="webcrypto#dfn-CryptoKey-slot-handle">`[[handle]]`</a> internal slot of |key|
-              cannot be accessed, then [= exception/throw =] an {{OperationError}}.
-            </p>
-          </li>
-          <li>
-            <dl class="switch">
-              <dt>If |format| is {{KeyFormat/"raw-public"}}:</dt>
-              <dd>
-                <ol>
-                  <li>
-                    <p>
-                      If the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot
-                      of |key| is not {{KeyType/"public"}}, then [= exception/throw =] an {{InvalidAccessError}}.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Let |data| be a [= byte sequence =] containing
-                      the raw octets of the key represented by the <a data-cite="webcrypto#dfn-CryptoKey-slot-handle">`[[handle]]`</a> internal slot of
-                      |key|.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Let |result| be |data|.
-                    </p>
-                  </li>
-                </ol>
-              </dd>
-              <dt>If |format| is {{KeyFormat/"raw-seed"}}:</dt>
-              <dd>
-                <ol>
-                  <li>
-                    <p>
-                      If the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot
-                      of |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Let |data| be a [= byte sequence =] containing the 32-byte seed represented by
-                      the <a data-cite="webcrypto#dfn-CryptoKey-slot-handle">`[[handle]]`</a>
-                      internal slot of |key|.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Let |result| be |data|.
-                    </p>
-                  </li>
-                </ol>
-              </dd>
-              <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
-              <dd>
-                <ol>
-                  <li>
-                    <p>
-                      Let |jwk| be a new {{JsonWebKey}}
-                      dictionary.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Let |keyAlgorithm| be the <a data-cite="webcrypto#dfn-CryptoKey-slot-algorithm">`[[algorithm]]`</a> internal slot of |key|.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Set the `kty` attribute of |jwk| to
-                      "`AKP`".
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Set the `alg` attribute of |jwk| to the
-                      {{Algorithm/name}} member of |keyAlgorithm|.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Set the {{JsonWebKey/pub}} attribute of |jwk|
-                      to the base64url encoded public key corresponding
-                      to the <a data-cite="webcrypto#dfn-CryptoKey-slot-handle">`[[handle]]`</a>
-                      internal slot of |key|.
-                    </p>
-                  </li>
-                  <li>
-                    <dl class="switch">
-                      <dt>
-                        If the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">`[[type]]`</a> internal slot
-                        of |key| is {{KeyType/"private"}}:
-                      </dt>
-                      <dd>
-                        Set the {{JsonWebKey/priv}} attribute of |jwk|
-                        to the base64url encoded 32-byte seed represented by
-                        the <a data-cite="webcrypto#dfn-CryptoKey-slot-handle">`[[handle]]`</a>
-                        internal slot of |key|.
-                      </dd>
-                    </dl>
-                  </li>
-                  <li>
-                    <p>
-                      Set the `key_ops` attribute of |jwk| to the {{CryptoKey/usages}} attribute of |key|.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Set the `ext` attribute of |jwk| to the <a data-cite="webcrypto#dfn-CryptoKey-slot-extractable">`[[extractable]]`</a> internal slot
-                      of |key|.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Let |result| be |jwk|.
-                    </p>
-                  </li>
-                </ol>
-              </dd>
-              <dt>Otherwise:</dt>
-              <dd>
-                <p>
-                  [= exception/throw =] a
-                  {{NotSupportedError}}.
-                </p>
-              </dd>
-            </dl>
-          </li>
-          <li>
-            <p>
-              Return |result|.
             </p>
           </li>
         </ol>

--- a/index.html
+++ b/index.html
@@ -7787,9 +7787,21 @@ dictionary Argon2Params : Algorithm {
       </section>
       <section id="hybrid-kems-operations-import-key">
         <h5>Import Key</h5>
-        <div class=note>
+        <div class=issue>
           <p>
-            TODO: {{KeyFormat/"pkcs8"}}.
+            {{KeyFormat/"pkcs8"}} import is so far unspecified.
+            [[draft-ietf-lamps-pq-composite-kem]] defines
+            `OneAsymmetricKey.privateKey` as an `OCTET STRING` containing
+            `mlkemSeed || tradSK`, where `mlkemSeed` is the 64-byte ML-KEM
+            `d || z` seed and |tradSK| is the traditional private key encoding.
+          </p>
+          <p>
+            Importing this representation would produce a usable decapsulation
+            key, but we cannot recover the 32-byte seed used by
+            {{KeyFormat/"raw-seed"}} and {{KeyFormat/"jwk"}}.
+            We could require |extractable| to be `false` which would remove those
+            cases, or otherwise define that seed-based export formats fail for keys
+            that are not backed by a 32-byte seed.
           </p>
         </div>
         <ol>
@@ -8232,9 +8244,24 @@ dictionary Argon2Params : Algorithm {
       </section>
       <section id="hybrid-kems-operations-export-key">
         <h5>Export Key</h5>
-        <div class=note>
+        <div class=issue>
           <p>
-            TODO: {{KeyFormat/"pkcs8"}}.
+            {{KeyFormat/"pkcs8"}} export is so far unspecified.
+            [[draft-ietf-lamps-pq-composite-kem]] defines
+            `OneAsymmetricKey.privateKey` as an `OCTET STRING` containing
+            `mlkemSeed || tradSK`, where `mlkemSeed` is the 64-byte ML-KEM
+            `d || z` seed and |tradSK| is the traditional private key encoding.
+          </p>
+          <p>
+            Exporting this format can work for generated keys, or keys imported
+            with the 32-byte seed used by {{KeyFormat/"raw-seed"}} and
+            {{KeyFormat/"jwk"}}, provided the implementation can derive and
+            serialize the component private keys. For keys imported from
+            {{KeyFormat/"pkcs8"}}, we only have the LAMPS component
+            private-key representation. That representation is sufficient for
+            decapsulation and for {{KeyFormat/"pkcs8"}} re-export, but we cannot
+            export it as {{KeyFormat/"raw-seed"}} or {{KeyFormat/"jwk"}} unless
+            the key is backed by a 32-byte seed.
           </p>
         </div>
         <ol>

--- a/index.html
+++ b/index.html
@@ -7555,6 +7555,16 @@ dictionary Argon2Params : Algorithm {
         </tbody>
       </table>
     </section>
+    <section id="hybrid-kems-jwk">
+      <h4>JSON Web Key Representation</h4>
+      <p>
+        Hybrid KEM keys use the "AKP" (Algorithm Key Pair) key type defined in [[draft-ietf-cose-dilithium-08]]
+        for JWK representation. The "alg" (algorithm) parameter identifies the specific hybrid KEM instance.
+        The public key is carried in the "pub" parameter. If a private key is included, it is represented
+        using the "priv" parameter. When expressed in JWK, all key parameters are base64url encoded.
+      </p>
+    </section>
+
     <section id="hybrid-kems-operations">
       <h4>Operations</h4>
       <section id="hybrid-kems-operations-encapsulate">
@@ -7952,10 +7962,21 @@ dictionary Argon2Params : Algorithm {
                   </li>
                   <li>
                     <p>
-                      If the {{JsonWebKey/alg}} field of |jwk| is not
-                      equal to the {{Algorithm/name}} member of
-                      |normalizedAlgorithm|, then [= exception/throw =] a
+                      If the {{JsonWebKey/alg}} field of |jwk| is not present,
+                      or its value does not identify the hybrid KEM instance
+                      indicated by the {{Algorithm/name}} member of
+                      |normalizedAlgorithm|,
+                      then [= exception/throw =] a
                       {{DataError}}.
+                    </p>
+                    <p class="note">
+                      The "alg" values registered in the
+                      IANA JSON Web Signature and Encryption Algorithms registry
+                      for the hybrid KEM instances defined by this specification
+                      are `MLKEM768-P256`, `MLKEM768-X25519`, and
+                      `MLKEM1024-P384`. Implementations should also accept other
+                      values from this registry that identify an algorithm
+                      utilizing the same hybrid KEM instance.
                     </p>
                   </li>
                   <li>


### PR DESCRIPTION
I had this lying around since March, gave it a rebase and updated references. I'm opening this as a draft PR to accomodate a discussion (and to get a preview link).

Proposes to add 3 Hybrid KEMs (per https://www.ietf.org/archive/id/draft-irtf-cfrg-concrete-hybrid-kems-03.html) as Web Cryptography algorithms. These three KEMs are exactly what [HPKE-PQ](https://datatracker.ietf.org/doc/draft-ietf-hpke-pq/) uses.

- MLKEM768-P256
- MLKEM768-X25519 (aka X-Wing)
- MLKEM1024-P384

---

<details>
<summary>Yanked SPKI / PKCS#8 discovery</summary>

SPKI import/export is specified using the Composite ML-KEM OIDs from [draft-ietf-lamps-pq-composite-kem](https://datatracker.ietf.org/doc/draft-ietf-lamps-pq-composite-kem/):

- `MLKEM768-X25519` -> `id-MLKEM768-X25519-SHA3-256` (`1.3.6.1.5.5.7.6.58`)
- `MLKEM768-P256` -> `id-MLKEM768-ECDH-P256-SHA3-256` (`1.3.6.1.5.5.7.6.59`)
- `MLKEM1024-P384` -> `id-MLKEM1024-ECDH-P384-SHA3-256` (`1.3.6.1.5.5.7.6.63`)

---

PKCS#8 is kept as an issue in the proposal for now. LAMPS encodes `OneAsymmetricKey.privateKey` as `mlkemSeed || tradSK`, while this draft's `raw-seed` and JWK private-key forms use the 32-byte seed from the CFRG Hybrid KEM `DeriveKeyPair` flow. Seed-backed keys should be able to export PKCS#8 if the implementation can derive and serialize the component private keys. PKCS#8-imported keys can be usable for decapsulation and PKCS#8 re-export, but cannot be exported as `raw-seed` or JWK unless the original 32-byte seed is also available. The proposal calls out whether `pkcs8` import should require `extractable` to be `false`, or whether seed-based export formats should fail for non-seed-backed keys.

Additionaly, `raw-private` export/import in the LAMPS `mlkemSeed || tradSK` definition might be an option to support in addition to `raw-seed`.

`raw-seed` must remain as-is to support HPKE-PQ.

---

I'm not married to either pkcs8, spki, or raw-private. But i at least did the due diligence for the proposal. Happy to adjust based on feedback.

</details>

WPTs: https://github.com/web-platform-tests/wpt/pull/59947


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/panva/webcrypto-modern-algos/pull/67.html" title="Last updated on Aug 7, 2026, 12:35 PM UTC (3b840c6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/webcrypto-modern-algos/67/617c196...panva:3b840c6.html" title="Last updated on Aug 7, 2026, 12:35 PM UTC (3b840c6)">Diff</a>